### PR TITLE
Add simple React example

### DIFF
--- a/examples/react-simple-example/output.js
+++ b/examples/react-simple-example/output.js
@@ -1,8 +1,8 @@
-import { jsxScanner } from '@coscan/jsx-scanner';
+import { coscan } from 'coscan';
 import { writeFile } from 'node:fs/promises';
 
 async function main() {
-  const results = await jsxScanner({
+  const results = await coscan({
     files: [
       'src/components/hello-component.tsx',
       'src/components/simple-component.tsx',

--- a/examples/react-simple-example/output.js
+++ b/examples/react-simple-example/output.js
@@ -1,0 +1,21 @@
+import { jsxScanner } from '@coscan/jsx-scanner';
+import { writeFile } from 'node:fs/promises';
+
+async function main() {
+  const results = await jsxScanner({
+    files: [
+      'src/components/hello-component.tsx',
+      'src/components/simple-component.tsx',
+      'src/components/entry-component.tsx',
+    ],
+  });
+
+  await writeFile('output.json', JSON.stringify(results, null, 2));
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error);
+  process.exit(1);
+}

--- a/examples/react-simple-example/package.json
+++ b/examples/react-simple-example/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@types/react": "^18.3.3",
-    "@coscan/jsx-scanner": "*"
+    "coscan": "*"
   },
   "peerDependencies": {},
   "scripts": {

--- a/examples/react-simple-example/package.json
+++ b/examples/react-simple-example/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@coscan/react-simple-example",
+  "version": "0.0.0",
+  "private": true,
+  "description": "",
+  "author": "Philip Bordallo",
+  "license": "MIT",
+  "type": "module",
+  "dependencies": {
+    "react": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@coscan/jsx-scanner": "*"
+  },
+  "peerDependencies": {},
+  "scripts": {
+    "start": "node ./output.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/examples/react-simple-example/src/components/entry-component.tsx
+++ b/examples/react-simple-example/src/components/entry-component.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { AnotherComponent } from '../components/simple-component';
+import { SimpleComponent } from './simple-component';
+
+export function Entry() {
+  return (
+    <>
+      <SimpleComponent disabled key="1" />
+      <AnotherComponent key="2" />
+    </>
+  );
+}

--- a/examples/react-simple-example/src/components/hello-component.tsx
+++ b/examples/react-simple-example/src/components/hello-component.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+function SimpleComponent() {
+  return <button type="button" autoFocus={false} contentEditable={true}>Simple Component</button>;
+}
+
+export function Hello() {
+  return <SimpleComponent />;
+}

--- a/examples/react-simple-example/src/components/simple-component.tsx
+++ b/examples/react-simple-example/src/components/simple-component.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+export function add(a: number, b: number) {
+  return a + b;
+}
+
+export const ExpressionComponent = function() {
+  return <div />;
+};
+
+export const ArrowComponent = () => {
+  return <div />;
+};
+
+type SimpleComponentProps = {
+  disabled: boolean;
+};
+
+export function SimpleComponent({ disabled }: SimpleComponentProps): JSX.Element {
+  const handleClick = () => {};
+  const value = true;
+  return (
+    <button type={`button`} onClick={handleClick} disabled={disabled} autoFocus={false} contentEditable={value}>
+      Simple Component
+    </button>
+  );
+}
+
+export function AnotherComponent() {
+  const value = true;
+  return <button type="button" autoFocus={false} contentEditable={value}>Simple Component</button>;
+}
+
+export function Example() {
+  return <AnotherComponent />;
+}

--- a/examples/react-simple-example/tsconfig.json
+++ b/examples/react-simple-example/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "workspaces": [
+        "examples/*",
         "packages/*"
       ],
       "devDependencies": {
@@ -25,6 +26,18 @@
         "dprint": "^0.47.2",
         "rollup": "^4.21.2",
         "typescript": "^5.6.2"
+      }
+    },
+    "examples/react-simple-example": {
+      "name": "@coscan/react-simple-example",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "react": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.3",
+        "coscan": "*"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1901,6 +1914,10 @@
       "resolved": "packages/jsx-scanner",
       "link": true
     },
+    "node_modules/@coscan/react-simple-example": {
+      "resolved": "examples/react-simple-example",
+      "link": true
+    },
     "node_modules/@dprint/darwin-arm64": {
       "version": "0.47.2",
       "resolved": "https://registry.npmjs.org/@dprint/darwin-arm64/-/darwin-arm64-0.47.2.tgz",
@@ -2404,6 +2421,24 @@
         "undici-types": "~6.19.2"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.12",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
+      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.5.tgz",
+      "integrity": "sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -2589,6 +2624,13 @@
     "node_modules/coscan": {
       "resolved": "packages/coscan",
       "link": true
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.7",
@@ -2794,7 +2836,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
@@ -2829,6 +2870,18 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -2879,6 +2932,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/regenerate": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "type": "module",
   "workspaces": [
+    "examples/*",
     "packages/*"
   ],
   "exports": {


### PR DESCRIPTION
This will add a simple React example to show case how coscan works.

Running `npm -w @coscan/react-simple-example run start` will create an output.json file that shows all the results.