### PR TITLE
Update jsx-scanner to handle expression and object props more consistently

### DIFF
--- a/packages/jsx-scanner/src/entities/prop.ts
+++ b/packages/jsx-scanner/src/entities/prop.ts
@@ -2,6 +2,8 @@ import {
   isIdentifier,
   isJsxAttribute,
   isJsxExpression,
+  isObjectLiteralExpression,
+  isPropertyAssignment,
   isStringLiteral,
   type JsxAttributeName,
   type JsxAttributes,
@@ -11,10 +13,14 @@ import {
 import { isBooleanLiteral } from '../guards/boolean-literal.ts';
 
 export type Prop = string;
-export type PropValue = string | boolean | undefined;
+export type PropValue = string | boolean | Record<string, string> | undefined;
 export type Props = {
   [prop: Prop]: PropValue;
 };
+
+function formatExpression(value: string): string {
+  return `Expression -> ${value}`;
+}
 
 function getPropValue(value?: JsxAttributeValue, sourceFile?: SourceFile): PropValue {
   // If a value is not defined, it means the prop is a boolean
@@ -35,8 +41,29 @@ function getPropValue(value?: JsxAttributeValue, sourceFile?: SourceFile): PropV
     }
 
     if (isIdentifier(value.expression)) {
-      return `Expression: {${expression}}`;
+      return formatExpression(expression);
     }
+
+    if (isObjectLiteralExpression(value.expression)) {
+      const entries = value.expression.properties
+        .map((prop) => {
+          if (isPropertyAssignment(prop)) {
+            const key = prop.name.getText(sourceFile);
+            const initializer = prop.initializer.getText(sourceFile);
+
+            const value = isStringLiteral(prop.initializer)
+              ? initializer.replace(/['"]+/g, '')
+              : formatExpression(initializer);
+
+            return [key, value];
+          }
+        })
+        .filter((entry) => entry !== undefined);
+
+      return Object.fromEntries(entries);
+    }
+
+    return expression;
   }
 }
 

--- a/packages/jsx-scanner/src/entities/prop.ts
+++ b/packages/jsx-scanner/src/entities/prop.ts
@@ -1,9 +1,13 @@
 import {
+  type Expression,
+  isArrayLiteralExpression,
   isIdentifier,
   isJsxAttribute,
   isJsxExpression,
+  isNumericLiteral,
   isObjectLiteralExpression,
   isPropertyAssignment,
+  isShorthandPropertyAssignment,
   isStringLiteral,
   type JsxAttributeName,
   type JsxAttributes,
@@ -12,29 +16,70 @@ import {
   type SourceFile,
 } from 'typescript';
 import { isBooleanLiteral } from '../guards/boolean-literal.ts';
+import { isNullLiteral } from '../guards/null-literal.ts';
 
 export type Prop = string;
-export type PropValue = string | boolean | ObjectPropValue | undefined;
+export type PropValue = string | boolean | ObjectPropValue | ExpressionPropValue | null | undefined;
 export type Props = {
   [prop: Prop]: PropValue;
 };
 
-function formatExpression(value: string): string {
+type ExpressionPropValue = `Expression -> ${string}`;
+
+function formatExpression(value: string): ExpressionPropValue {
   return `Expression -> ${value}`;
 }
 
-type ObjectPropValue = Record<string, string>;
+type PropertyAssignmentValue =
+  | string
+  | number
+  | boolean
+  | PropertyAssignmentValue[]
+  | ObjectPropValue
+  | null
+  | undefined;
+
+function getPropertyAssignmentValue(initializer: Expression, sourceFile?: SourceFile): PropertyAssignmentValue {
+  if (isStringLiteral(initializer)) {
+    return initializer.getText(sourceFile).replace(/['"]+/g, '');
+  }
+
+  if (isNumericLiteral(initializer) || isBooleanLiteral(initializer)) {
+    return JSON.parse(initializer.getText(sourceFile));
+  }
+
+  if (isArrayLiteralExpression(initializer)) {
+    return initializer.elements.map((element) => getPropertyAssignmentValue(element, sourceFile));
+  }
+
+  if (isObjectLiteralExpression(initializer)) {
+    return parseObjectExpression(initializer, sourceFile);
+  }
+
+  if (isIdentifier(initializer)) {
+    return formatExpression(initializer.getText(sourceFile));
+  }
+
+  if (isNullLiteral(initializer)) {
+    return null;
+  }
+}
+
+type ObjectPropValue = Record<string, unknown>;
 
 function parseObjectExpression(expression: ObjectLiteralExpression, sourceFile?: SourceFile): ObjectPropValue {
   const entries = expression.properties
     .map((property) => {
       if (isPropertyAssignment(property)) {
         const key = property.name.getText(sourceFile);
-        const initializer = property.initializer.getText(sourceFile);
+        const value = getPropertyAssignmentValue(property.initializer, sourceFile);
 
-        const value = isStringLiteral(property.initializer)
-          ? initializer.replace(/['"]+/g, '')
-          : formatExpression(initializer);
+        return [key, value];
+      }
+
+      if (isShorthandPropertyAssignment(property)) {
+        const key = property.name.getText(sourceFile);
+        const value = formatExpression(key);
 
         return [key, value];
       }
@@ -44,7 +89,11 @@ function parseObjectExpression(expression: ObjectLiteralExpression, sourceFile?:
   return Object.fromEntries(entries);
 }
 
-function getPropValue(value?: JsxAttributeValue, sourceFile?: SourceFile): PropValue {
+function getPropValue(
+  value?: JsxAttributeValue,
+  isParsableObjectPropValue?: boolean,
+  sourceFile?: SourceFile,
+): PropValue {
   // If a value is not defined, it means the prop is a boolean
   if (value === undefined) {
     return true;
@@ -54,7 +103,6 @@ function getPropValue(value?: JsxAttributeValue, sourceFile?: SourceFile): PropV
     return value.text;
   }
 
-  // If the value is an expression, parse it
   if (isJsxExpression(value) && value.expression) {
     const expression = value.expression.getText(sourceFile);
 
@@ -66,7 +114,11 @@ function getPropValue(value?: JsxAttributeValue, sourceFile?: SourceFile): PropV
       return formatExpression(expression);
     }
 
-    if (isObjectLiteralExpression(value.expression)) {
+    if (isNullLiteral(value.expression)) {
+      return null;
+    }
+
+    if (isObjectLiteralExpression(value.expression) && isParsableObjectPropValue) {
       return parseObjectExpression(value.expression, sourceFile);
     }
 
@@ -84,8 +136,9 @@ export function getProps({ properties }: JsxAttributes, sourceFile?: SourceFile)
   properties.forEach((prop) => {
     if (isJsxAttribute(prop)) {
       const key = getPropKey(prop.name, sourceFile);
+      const isParsableObjectPropValue = key === 'style';
 
-      props[key] = getPropValue(prop.initializer, sourceFile);
+      props[key] = getPropValue(prop.initializer, isParsableObjectPropValue, sourceFile);
     }
   });
 

--- a/packages/jsx-scanner/src/guards/null-literal.ts
+++ b/packages/jsx-scanner/src/guards/null-literal.ts
@@ -1,0 +1,5 @@
+import { Node, type NullLiteral, SyntaxKind } from 'typescript';
+
+export function isNullLiteral(node: Node): node is NullLiteral {
+  return node.kind === SyntaxKind.NullKeyword;
+}


### PR DESCRIPTION
This will:
- Update how jsx-scanner handles expression props, now it prefixes them with `Expression ->`
- Update jsx-scanner to parse object props like `style`
- Update jsx-scanner to handle `null` values for props