### PR TITLE
Clean up discovery

### DIFF
--- a/packages/jsx-scanner/src/entities/definition.ts
+++ b/packages/jsx-scanner/src/entities/definition.ts
@@ -4,7 +4,6 @@ import type { Position } from './position.ts';
 
 export type Definition = {
   type: 'definition';
-  returnType: string;
   filePath: FilePath;
   positionPath: string;
   componentName: ComponentName;

--- a/packages/jsx-scanner/src/parsers/element-parser.ts
+++ b/packages/jsx-scanner/src/parsers/element-parser.ts
@@ -26,7 +26,7 @@ export function elementParser({ discoveries, node, importCollection, sourceFile 
   const props = getProps(element.attributes, sourceFile);
   const componentId = getComponentId(name, importCollection, relativeFilePath);
 
-  const discovery: Instance = {
+  const instance: Instance = {
     type: 'instance',
     componentName: name,
     componentId,
@@ -39,5 +39,5 @@ export function elementParser({ discoveries, node, importCollection, sourceFile 
     endPosition,
   };
 
-  discoveries.push(discovery);
+  discoveries.push(instance);
 }

--- a/packages/jsx-scanner/src/parsers/element-parser.ts
+++ b/packages/jsx-scanner/src/parsers/element-parser.ts
@@ -2,6 +2,7 @@ import { isJsxSelfClosingElement, type JsxElement, type JsxSelfClosingElement, t
 import { type ComponentName, getComponentId } from '../entities/component.ts';
 import { getRelativeFilePath } from '../entities/file.ts';
 import type { ImportCollection } from '../entities/import.ts';
+import type { Instance } from '../entities/instance.ts';
 import { getPosition } from '../entities/position.ts';
 import { getProps } from '../entities/prop.ts';
 import type { Discovery } from '../entities/scanner.ts';
@@ -25,7 +26,7 @@ export function elementParser({ discoveries, node, importCollection, sourceFile 
   const props = getProps(element.attributes, sourceFile);
   const componentId = getComponentId(name, importCollection, relativeFilePath);
 
-  discoveries.push({
+  const discovery: Instance = {
     type: 'instance',
     componentName: name,
     componentId,
@@ -36,5 +37,7 @@ export function elementParser({ discoveries, node, importCollection, sourceFile 
     props,
     startPosition,
     endPosition,
-  });
+  };
+
+  discoveries.push(discovery);
 }

--- a/packages/jsx-scanner/src/parsers/function-parser.ts
+++ b/packages/jsx-scanner/src/parsers/function-parser.ts
@@ -68,7 +68,7 @@ export function functionParser({
 
   const componentId = getComponentId(componentName, importCollection, relativeFilePath);
 
-  const discovery: Definition = {
+  const definition: Definition = {
     type: 'definition',
     componentName,
     componentId,
@@ -78,5 +78,5 @@ export function functionParser({
     endPosition,
   };
 
-  discoveries.push(discovery);
+  discoveries.push(definition);
 }

--- a/packages/jsx-scanner/src/parsers/function-parser.ts
+++ b/packages/jsx-scanner/src/parsers/function-parser.ts
@@ -8,6 +8,7 @@ import {
   type TypeChecker,
 } from 'typescript';
 import { getComponentId } from '../entities/component.ts';
+import type { Definition } from '../entities/definition.ts';
 import { getRelativeFilePath } from '../entities/file.ts';
 import type { ImportCollection } from '../entities/import.ts';
 import { getPosition } from '../entities/position.ts';
@@ -67,14 +68,15 @@ export function functionParser({
 
   const componentId = getComponentId(componentName, importCollection, relativeFilePath);
 
-  discoveries.push({
+  const discovery: Definition = {
     type: 'definition',
     componentName,
     componentId,
-    returnType,
-    startPosition,
-    endPosition,
     filePath: relativeFilePath,
     positionPath: `${relativeFilePath}:${startPosition.line}:${startPosition.character}`,
-  });
+    startPosition,
+    endPosition,
+  };
+
+  discoveries.push(discovery);
 }


### PR DESCRIPTION
This will clean up definition doing the following:
- Remove `returnType` as it isn't needed for the reporter, more so finding the right things
- Use type annotations so it's easier to find use-cases
- Reorganize where `filePath` and `positionPath` exist