### PR TITLE
Move to turbo over wireit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,8 @@
   ],
   "postCreateCommand": "sudo chown node node_modules",
   "containerEnv": {
-    "WIREIT_LOGGER": "simple"
+    "NODE_OPTIONS": "--no-warnings=ExperimentalWarning",
+    "TURBO_TELEMETRY_DISABLED": "1"
   },
   "customizations": {
     "vscode": {
@@ -29,7 +30,6 @@
         "dbaeumer.vscode-eslint",
         "dprint.dprint",
         "EditorConfig.EditorConfig",
-        "Google.wireit",
         "streetsidesoftware.code-spell-checker"
       ]
     }

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@ dist/
 output.json
 tsconfig.tsbuildinfo
 
-# Cache directory for wireit
-.wireit/
+# Cache directory for turbo
+.turbo/
 
 # node.js packages
 node_modules/

--- a/devtools/rollup/package.json
+++ b/devtools/rollup/package.json
@@ -28,6 +28,9 @@
   "peerDependencies": {},
   "scripts": {
     "build": "rollup -c ./rollup.config.js",
-    "types": "tsc"
+    "build:watch": "rollup -c ./rollup.config.js --watch",
+    "clean": "rm -rf .turbo/ && rm -rf dist/ && rm -rf tsconfig.tsbuildinfo",
+    "type": "tsc --build --pretty",
+    "type:watch": "tsc --build --preserveWatchOutput --watch"
   }
 }

--- a/dictionaries/en-us.dic
+++ b/dictionaries/en-us.dic
@@ -5,4 +5,3 @@ dbaeumer
 devcontainers
 dprint
 tsbuildinfo
-wireit

--- a/examples/react-simple-example/package.json
+++ b/examples/react-simple-example/package.json
@@ -15,7 +15,6 @@
   },
   "peerDependencies": {},
   "scripts": {
-    "start": "node ./output.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "output": "node ./output.js"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
         "@types/node": "^22.5.4",
         "dprint": "^0.47.2",
         "jest": "^29.7.0",
-        "typescript": "^5.6.2",
-        "wireit": "^0.14.9"
+        "turbo": "^2.1.2",
+        "typescript": "^5.6.2"
       }
     },
     "devtools/babel-config": {
@@ -2873,44 +2873,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@rollup/plugin-babel": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.0.4.tgz",
@@ -3683,42 +3645,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-3.0.1.tgz",
-      "integrity": "sha512-vjtV3hiLqYDNRoiAv0zC4QaGAMPomEoq83PRmYIofPswwZurCeWR5LByXm7SyoL0Zh5+2z0+HC7jG8gSZJUh0w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-4.0.0.tgz",
-      "integrity": "sha512-l/mOwLWs7BQIgOKrL46dIAbyCKvPV7YJPDspkuc88rHsZRlg3hptUGdU7Trv0VFP4d3xnSGBQrKu5ZvGB7UeIw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -3859,31 +3785,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/ci-info": {
@@ -4333,39 +4234,12 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fastq": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -4501,19 +4375,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -4627,19 +4488,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-builtin-module": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
@@ -4672,16 +4520,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4700,19 +4538,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-module": {
@@ -6582,13 +6407,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonc-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -6703,16 +6521,6 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -7042,18 +6850,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -7067,27 +6863,6 @@
         {
           "type": "opencollective",
           "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
         }
       ],
       "license": "MIT"
@@ -7110,19 +6885,6 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -7262,27 +7024,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.2.tgz",
@@ -7317,30 +7058,6 @@
         "@rollup/rollup-win32-ia32-msvc": "4.21.2",
         "@rollup/rollup-win32-x64-msvc": "4.21.2",
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/semver": {
@@ -7597,6 +7314,108 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/turbo": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.1.2.tgz",
+      "integrity": "sha512-Jb0rbU4iHEVQ18An/YfakdIv9rKnd3zUfSE117EngrfWXFHo3RndVH96US3GsT8VHpwTncPePDBT2t06PaFLrw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "turbo": "bin/turbo"
+      },
+      "optionalDependencies": {
+        "turbo-darwin-64": "2.1.2",
+        "turbo-darwin-arm64": "2.1.2",
+        "turbo-linux-64": "2.1.2",
+        "turbo-linux-arm64": "2.1.2",
+        "turbo-windows-64": "2.1.2",
+        "turbo-windows-arm64": "2.1.2"
+      }
+    },
+    "node_modules/turbo-darwin-64": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.1.2.tgz",
+      "integrity": "sha512-3TEBxHWh99h2yIzkuIigMEOXt/ItYQp0aPiJjPd1xN4oDcsKK5AxiFKPH9pdtfIBzYsY59kQhZiFj0ELnSP7Bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-darwin-arm64": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.1.2.tgz",
+      "integrity": "sha512-he0miWNq2WxJzsH82jS2Z4MXpnkzn9SH8a79iPXiJkq25QREImucscM4RPasXm8wARp91pyysJMq6aasD45CeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.1.2.tgz",
+      "integrity": "sha512-fKUBcc0rK8Vdqv5a/E3CSpMBLG1bzwv+Q0Q83F8fG2ZfNCNKGbcEYABdonNZkkx141Rj03cZQFCgxu3MVEGU+A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.1.2.tgz",
+      "integrity": "sha512-sV8Bpmm0WiuxgbhxymcC7wSsuxfBBieI98GegSwbr/bs1ANAgzCg93urIrdKdQ3/b31zZxQwcaP4FBF1wx1Qdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.1.2.tgz",
+      "integrity": "sha512-wcmIJZI9ORT9ykHGliFE6kWRQrlH930QGSjSgWC8uFChFFuOyUlvC7ttcxuSvU9VqC7NF4C+GVAcFJQ8lTjN7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.1.2.tgz",
+      "integrity": "sha512-zdnXjrhk7YO6CP+Q5wPueEvOCLH4lDa6C4rrwiakcWcPgcQGbVozJlo4uaQ6awo8HLWQEvOwu84RkWTdLAc/Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -7756,30 +7575,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/wireit": {
-      "version": "0.14.9",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.14.9.tgz",
-      "integrity": "sha512-hFc96BgyslfO1WGSzQqOVYd5N3TB+4u9w70L9GHR/T7SYjvFmeznkYMsRIjMLhPcVabCEYPW1vV66wmIVDs+dQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "workspaces": [
-        "vscode-extension",
-        "website"
-      ],
-      "dependencies": {
-        "brace-expansion": "^4.0.0",
-        "chokidar": "^3.5.3",
-        "fast-glob": "^3.2.11",
-        "jsonc-parser": "^3.0.0",
-        "proper-lockfile": "^4.1.2"
-      },
-      "bin": {
-        "wireit": "bin/wireit.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -7929,6 +7724,9 @@
       "name": "@coscan/json-reporter",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@coscan/jsx-scanner": "*"
+      },
       "devDependencies": {
         "@coscan/rollup": "*"
       }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "examples/*",
     "packages/*"
   ],
+  "packageManager": "npm@10.8.2",
   "dependencies": {},
   "devDependencies": {
     "@dprint/json": "^0.19.3",
@@ -19,16 +20,14 @@
     "@types/node": "^22.5.4",
     "dprint": "^0.47.2",
     "jest": "^29.7.0",
-    "typescript": "^5.6.2",
-    "wireit": "^0.14.9"
+    "turbo": "^2.1.2",
+    "typescript": "^5.6.2"
   },
   "peerDependencies": {},
   "scripts": {
-    "clean-cache": "rm -rf packages/*/.wireit/*/cache packages/*/dist packages/*/tsconfig.tsbuildinfo",
-    "coscan": "npm -w packages/coscan run --",
-    "json-reporter": "npm -w packages/json-reporter run --",
-    "jsx-scanner": "npm -w packages/jsx-scanner run --",
-    "rollup": "npm -w devtools/rollup run --",
-    "example": "npm -w examples/react-simple-example run --"
+    "build": "turbo run build",
+    "start": "turbo run start",
+    "clean": "turbo run clean",
+    "test": "turbo run test"
   }
 }

--- a/packages/coscan/package.json
+++ b/packages/coscan/package.json
@@ -27,63 +27,10 @@
   },
   "peerDependencies": {},
   "scripts": {
-    "build": "wireit",
-    "start": "wireit",
-    "rollup:build": "wireit",
-    "rollup:watch": "wireit",
-    "type:build": "wireit",
-    "type:watch": "wireit"
-  },
-  "wireit": {
-    "build": {
-      "command": "echo >> /dev/null",
-      "dependencies": [
-        "../jsx-scanner:build",
-        "rollup:build",
-        "type:build"
-      ]
-    },
-    "start": {
-      "command": "cat",
-      "service": true,
-      "dependencies": [
-        "../jsx-scanner:build",
-        "rollup:watch",
-        "type:watch"
-      ]
-    },
-    "rollup:build": {
-      "command": "rollup -c ./rollup.config.js",
-      "files": [
-        "./src/**/*.ts",
-        "./rollup.config.js"
-      ],
-      "output": [
-        "./dist/**/main.js",
-        "./dist/**/main.cjs"
-      ]
-    },
-    "rollup:watch": {
-      "command": "rollup -c ./rollup.config.js --watch",
-      "service": true,
-      "clean": false
-    },
-    "type:build": {
-      "command": "tsc --build --pretty",
-      "files": [
-        "./src/**/*.ts",
-        "./tsconfig.json"
-      ],
-      "output": [
-        "./dist/**/*.d.ts",
-        "./dist/**/*.d.ts.map",
-        "./dist/tsconfig.tsbuildinfo"
-      ]
-    },
-    "type:watch": {
-      "command": "tsc --build --emitDeclarationOnly --preserveWatchOutput --watch",
-      "service": true,
-      "clean": false
-    }
+    "build": "rollup -c ./rollup.config.js",
+    "build:watch": "rollup -c ./rollup.config.js --watch",
+    "clean": "rm -rf .turbo/ && rm -rf dist/ && rm -rf tsconfig.tsbuildinfo",
+    "type": "tsc --build --pretty",
+    "type:watch": "tsc --build --preserveWatchOutput --watch"
   }
 }

--- a/packages/json-reporter/package.json
+++ b/packages/json-reporter/package.json
@@ -18,67 +18,18 @@
   "browserslist": [
     "extends @coscan/browserslist-config"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "@coscan/jsx-scanner": "*"
+  },
   "devDependencies": {
     "@coscan/rollup": "*"
   },
   "peerDependencies": {},
   "scripts": {
-    "build": "wireit",
-    "start": "wireit",
-    "rollup:build": "wireit",
-    "rollup:watch": "wireit",
-    "type:build": "wireit",
-    "type:watch": "wireit"
-  },
-  "wireit": {
-    "build": {
-      "command": "echo >> /dev/null",
-      "dependencies": [
-        "rollup:build",
-        "type:build"
-      ]
-    },
-    "start": {
-      "command": "cat",
-      "service": true,
-      "dependencies": [
-        "rollup:watch",
-        "type:watch"
-      ]
-    },
-    "rollup:build": {
-      "command": "rollup -c ./rollup.config.js",
-      "files": [
-        "./src/**/*.ts",
-        "./rollup.config.js"
-      ],
-      "output": [
-        "./dist/**/main.js",
-        "./dist/**/main.cjs"
-      ]
-    },
-    "rollup:watch": {
-      "command": "rollup -c ./rollup.config.js --watch",
-      "service": true,
-      "clean": false
-    },
-    "type:build": {
-      "command": "tsc --build --pretty",
-      "files": [
-        "./src/**/*.ts",
-        "./tsconfig.json"
-      ],
-      "output": [
-        "./dist/**/*.d.ts",
-        "./dist/**/*.d.ts.map",
-        "./dist/tsconfig.tsbuildinfo"
-      ]
-    },
-    "type:watch": {
-      "command": "tsc --build --emitDeclarationOnly --preserveWatchOutput --watch",
-      "service": true,
-      "clean": false
-    }
+    "build": "rollup -c ./rollup.config.js",
+    "build:watch": "rollup -c ./rollup.config.js --watch",
+    "clean": "rm -rf .turbo/ && rm -rf dist/ && rm -rf tsconfig.tsbuildinfo",
+    "type": "tsc --build --pretty",
+    "type:watch": "tsc --build --preserveWatchOutput --watch"
   }
 }

--- a/packages/jsx-scanner/package.json
+++ b/packages/jsx-scanner/package.json
@@ -26,62 +26,11 @@
     "typescript": ">=5"
   },
   "scripts": {
-    "build": "wireit",
-    "start": "wireit",
-    "rollup:build": "wireit",
-    "rollup:watch": "wireit",
-    "type:build": "wireit",
-    "type:watch": "wireit",
+    "build": "rollup -c ./rollup.config.js",
+    "build:watch": "rollup -c ./rollup.config.js --watch",
+    "clean": "rm -rf .turbo/ && rm -rf dist/ && rm -rf tsconfig.tsbuildinfo",
+    "type": "tsc --build --pretty",
+    "type:watch": "tsc --build --preserveWatchOutput --watch",
     "test": "jest"
-  },
-  "wireit": {
-    "build": {
-      "command": "echo >> /dev/null",
-      "dependencies": [
-        "rollup:build",
-        "type:build"
-      ]
-    },
-    "start": {
-      "command": "cat",
-      "service": true,
-      "dependencies": [
-        "rollup:watch",
-        "type:watch"
-      ]
-    },
-    "rollup:build": {
-      "command": "rollup -c ./rollup.config.js",
-      "files": [
-        "./src/**/*.ts",
-        "./rollup.config.js"
-      ],
-      "output": [
-        "./dist/**/main.js",
-        "./dist/**/main.cjs"
-      ]
-    },
-    "rollup:watch": {
-      "command": "rollup -c ./rollup.config.js --watch",
-      "service": true,
-      "clean": false
-    },
-    "type:build": {
-      "command": "tsc --build --pretty",
-      "files": [
-        "./src/**/*.ts",
-        "./tsconfig.json"
-      ],
-      "output": [
-        "./dist/**/*.d.ts",
-        "./dist/**/*.d.ts.map",
-        "./dist/tsconfig.tsbuildinfo"
-      ]
-    },
-    "type:watch": {
-      "command": "tsc --build --emitDeclarationOnly --preserveWatchOutput --watch",
-      "service": true,
-      "clean": false
-    }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "remoteCache": {
+    "enabled": false
+  },
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build", "^type"],
+      "cache": true,
+      "outputs": [
+        "dist/**/*.js",
+        "dist/**/*.cjs"
+      ]
+    },
+    "build:watch": {
+      "dependsOn": ["^build:watch"],
+      "cache": false
+    },
+    "clean": {
+      "dependsOn": ["^clean"],
+      "cache": false
+    },
+    "start": {
+      "dependsOn": ["^build:watch", "^type:watch"],
+      "cache": false,
+      "persistent": true
+    },
+    "test": {
+      "dependsOn": ["^test"],
+      "cache": false
+    },
+    "test:watch": {
+      "dependsOn": ["^test:watch"],
+      "cache": false
+    },
+    "type": {
+      "dependsOn": ["^type"],
+      "cache": true,
+      "outputs": [
+        "dist/**/*.d.ts",
+        "dist/**/*.d.ts.map",
+        "tsconfig.tsbuildinfo"
+      ]
+    },
+    "type:watch": {
+      "dependsOn": [],
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
This will migrate from [`wireit`](https://github.com/google/wireit) to [`turbo`](https://github.com/vercel/turborepo/tree/main) as `turbo` is:
- Easier to maintain a centralized configuration for monorepos
- Removes the need to manually track dependencies
- Has better cache management