### PR TITLE
Add ability to handle fragments

### DIFF
--- a/packages/jsx-scanner/src/entities/component.ts
+++ b/packages/jsx-scanner/src/entities/component.ts
@@ -2,7 +2,7 @@ import { isBuiltInHtml } from '../guards/built-in-html.ts';
 import { isBuiltInSvg } from '../guards/built-in-svg.ts';
 import { type FilePath } from './file.ts';
 import { type ImportCollection, type ImportPath } from './import.ts';
-import type { Position } from './position.ts';
+import type { Position, PositionPath } from './position.ts';
 import type { Props } from './prop.ts';
 import { createUniqueId, type UniqueId } from './unique-id.ts';
 
@@ -14,7 +14,7 @@ export type ComponentDefinition = {
   componentName: ComponentName;
   componentId: ComponentId;
   filePath: FilePath;
-  positionPath: string;
+  positionPath: PositionPath;
   startPosition: Position;
   endPosition: Position;
 };
@@ -25,7 +25,7 @@ export type ComponentInstance = {
   componentId: ComponentId;
   filePath: FilePath;
   importPath?: ImportPath;
-  positionPath: string;
+  positionPath: PositionPath;
   isSelfClosing: boolean;
   props: Props;
   startPosition: Position;

--- a/packages/jsx-scanner/src/entities/position.ts
+++ b/packages/jsx-scanner/src/entities/position.ts
@@ -1,4 +1,5 @@
 import { getLineAndCharacterOfPosition, type SourceFile } from 'typescript';
+import type { FilePath } from './file.ts';
 
 const ZERO_INDEX_OFFSET = 1;
 
@@ -14,4 +15,10 @@ export function getPosition(position: number, sourceFile: SourceFile): Position 
     line: line + ZERO_INDEX_OFFSET,
     character: character,
   };
+}
+
+export type PositionPath = string;
+
+export function getPositionPath(position: Position, filePath: FilePath): PositionPath {
+  return `${filePath}:${position.line}:${position.character}`;
 }

--- a/packages/jsx-scanner/src/parsers/fragment-parser.ts
+++ b/packages/jsx-scanner/src/parsers/fragment-parser.ts
@@ -1,0 +1,38 @@
+import type { JsxFragment, SourceFile } from 'typescript';
+import { type ComponentInstance, type ComponentName, getComponentId } from '../entities/component.ts';
+import { getRelativeFilePath } from '../entities/file.ts';
+import type { ImportCollection } from '../entities/import.ts';
+import { getPosition, getPositionPath } from '../entities/position.ts';
+import type { JsxScannerDiscovery } from '../entities/scanner.ts';
+
+type FragmentParserArgs = {
+  discoveries: JsxScannerDiscovery[];
+  node: JsxFragment;
+  importCollection: ImportCollection;
+  sourceFile: SourceFile;
+};
+
+export function fragmentParser({ node, sourceFile, importCollection, discoveries }: FragmentParserArgs) {
+  const startPosition = getPosition(node.getStart(sourceFile), sourceFile);
+  const endPosition = getPosition(node.getEnd(), sourceFile);
+  const relativeFilePath = getRelativeFilePath(sourceFile);
+
+  const componentName: ComponentName = 'Fragment';
+
+  const componentId = getComponentId(componentName, importCollection, relativeFilePath);
+  const positionPath = getPositionPath(startPosition, relativeFilePath);
+
+  const instance: ComponentInstance = {
+    type: 'instance',
+    componentName,
+    componentId,
+    filePath: relativeFilePath,
+    positionPath,
+    isSelfClosing: false,
+    props: {},
+    startPosition,
+    endPosition,
+  };
+
+  discoveries.push(instance);
+}

--- a/packages/jsx-scanner/src/parsers/parser.test.ts
+++ b/packages/jsx-scanner/src/parsers/parser.test.ts
@@ -194,6 +194,20 @@ describe(parser, () => {
     expect(output.discoveries).toHaveLength(0);
   });
 
+  it('works with fragments', () => {
+    const output = renderWithConfig(`
+      import React, { Fragment } from 'react';
+      function App() {
+        return <>Hello</>;
+      }
+    `);
+
+    const parse = parser(output);
+    parse(output.sourceFile);
+
+    expect(output.discoveries).toHaveLength(2);
+  });
+
   it('works with unresolved imports', () => {
     const output = renderWithConfig(`
       import React from './blah.ts';

--- a/packages/jsx-scanner/src/parsers/parser.ts
+++ b/packages/jsx-scanner/src/parsers/parser.ts
@@ -5,6 +5,7 @@ import {
   isFunctionExpression,
   isImportClause,
   isJsxElement,
+  isJsxFragment,
   isJsxSelfClosingElement,
   isVariableDeclaration,
   type ModuleResolutionCache,
@@ -16,6 +17,7 @@ import {
 import { type ImportCollection } from '../entities/import.ts';
 import { type JsxScannerDiscovery } from '../entities/scanner.ts';
 import { elementParser } from './element-parser.ts';
+import { fragmentParser } from './fragment-parser.ts';
 import { functionParser } from './function-parser.ts';
 import { importParser } from './import-parser.ts';
 
@@ -56,6 +58,10 @@ export function parser({
 
     if (isJsxElement(node) || isJsxSelfClosingElement(node)) {
       elementParser({ discoveries, importCollection, node, sourceFile });
+    }
+
+    if (isJsxFragment(node)) {
+      fragmentParser({ discoveries, importCollection, node, sourceFile });
     }
 
     if (isImportClause(node)) {


### PR DESCRIPTION
This will add the ability to handle [fragments `<></>`](https://react.dev/reference/react/Fragment) as a discoverable item.