### PR TITLE
Clean up getPositionPath

### DIFF
--- a/packages/jsx-scanner/src/parsers/element-parser.ts
+++ b/packages/jsx-scanner/src/parsers/element-parser.ts
@@ -3,7 +3,7 @@ import { type ComponentName, getComponentId } from '../entities/component.ts';
 import type { ComponentInstance } from '../entities/component.ts';
 import { getRelativeFilePath } from '../entities/file.ts';
 import type { ImportCollection } from '../entities/import.ts';
-import { getPosition } from '../entities/position.ts';
+import { getPosition, getPositionPath } from '../entities/position.ts';
 import { getProps } from '../entities/prop.ts';
 import type { JsxScannerDiscovery } from '../entities/scanner.ts';
 
@@ -20,19 +20,22 @@ export function elementParser({ discoveries, node, importCollection, sourceFile 
 
   const isSelfClosing = isJsxSelfClosingElement(node);
   const element = isSelfClosing ? node : node.openingElement;
-  const relativeFilePath = getRelativeFilePath(sourceFile);
 
-  const name: ComponentName = element.tagName.getText(sourceFile);
+  const relativeFilePath = getRelativeFilePath(sourceFile);
+  const positionPath = getPositionPath(startPosition, relativeFilePath);
+
+  const componentName: ComponentName = element.tagName.getText(sourceFile);
+  const componentId = getComponentId(componentName, importCollection, relativeFilePath);
+
   const props = getProps(element.attributes, sourceFile);
-  const componentId = getComponentId(name, importCollection, relativeFilePath);
 
   const instance: ComponentInstance = {
     type: 'instance',
-    componentName: name,
+    componentName,
     componentId,
     filePath: relativeFilePath,
-    importPath: importCollection.get(name),
-    positionPath: `${relativeFilePath}:${startPosition.line}:${startPosition.character}`,
+    importPath: importCollection.get(componentName),
+    positionPath,
     isSelfClosing,
     props,
     startPosition,

--- a/packages/jsx-scanner/src/parsers/fragment-parser.ts
+++ b/packages/jsx-scanner/src/parsers/fragment-parser.ts
@@ -15,12 +15,12 @@ type FragmentParserArgs = {
 export function fragmentParser({ node, sourceFile, importCollection, discoveries }: FragmentParserArgs) {
   const startPosition = getPosition(node.getStart(sourceFile), sourceFile);
   const endPosition = getPosition(node.getEnd(), sourceFile);
+
   const relativeFilePath = getRelativeFilePath(sourceFile);
+  const positionPath = getPositionPath(startPosition, relativeFilePath);
 
   const componentName: ComponentName = 'Fragment';
-
   const componentId = getComponentId(componentName, importCollection, relativeFilePath);
-  const positionPath = getPositionPath(startPosition, relativeFilePath);
 
   const instance: ComponentInstance = {
     type: 'instance',

--- a/packages/jsx-scanner/src/parsers/function-parser.ts
+++ b/packages/jsx-scanner/src/parsers/function-parser.ts
@@ -11,7 +11,7 @@ import { getComponentId } from '../entities/component.ts';
 import type { ComponentDefinition } from '../entities/component.ts';
 import { getRelativeFilePath } from '../entities/file.ts';
 import type { ImportCollection } from '../entities/import.ts';
-import { getPosition } from '../entities/position.ts';
+import { getPosition, getPositionPath } from '../entities/position.ts';
 import type { JsxScannerDiscovery } from '../entities/scanner.ts';
 import { isElementReturn } from '../guards/element-return.ts';
 
@@ -61,9 +61,10 @@ export function functionParser({
   const startPosition = getPosition(node.getStart(sourceFile), sourceFile);
   const endPosition = getPosition(node.getEnd(), sourceFile);
 
-  const componentName = givenName?.getText(sourceFile) ?? '';
   const relativeFilePath = getRelativeFilePath(sourceFile);
+  const positionPath = getPositionPath(startPosition, relativeFilePath);
 
+  const componentName = givenName?.getText(sourceFile) ?? '';
   const componentId = getComponentId(componentName, importCollection, relativeFilePath);
 
   const definition: ComponentDefinition = {
@@ -71,7 +72,7 @@ export function functionParser({
     componentName,
     componentId,
     filePath: relativeFilePath,
-    positionPath: `${relativeFilePath}:${startPosition.line}:${startPosition.character}`,
+    positionPath,
     startPosition,
     endPosition,
   };


### PR DESCRIPTION
This will move the logic to create the `PositionPath` to a singular function instead of being spread out in multiple spots.