### PR TITLE
Clean up json reporter configuration

### DIFF
--- a/packages/coscan/README.md
+++ b/packages/coscan/README.md
@@ -23,6 +23,6 @@ coscan({
 | Name       | Type                   | Default                          | Description                                                           |
 | ---------- | ---------------------- | -------------------------------- | --------------------------------------------------------------------- |
 | `files`    | `string[]`             | `[]`                             | Files to be scanned, can be an entry into an app or individual files. |
-| `reporter` | [`Reporter`][Reporter] | `{ type: 'json', details 'raw }` | Reporter to use for output.                                           |
+| `reporter` | [`Reporter`][Reporter] | `{ type: 'json', detail: 'raw }` | Reporter to use for output.                                           |
 
 [Reporter]: ./src/entities/coscan.ts#L4

--- a/packages/coscan/README.md
+++ b/packages/coscan/README.md
@@ -20,9 +20,9 @@ coscan({
 
 ## Configuration
 
-| Name       | Type                   | Default        | Description                                                           |
-| ---------- | ---------------------- | -------------- | --------------------------------------------------------------------- |
-| `files`    | `string[]`             | `[]`           | Files to be scanned, can be an entry into an app or individual files. |
-| `reporter` | [`Reporter`][Reporter] | `jsonReporter` | Reporter to use for output.                                           |
+| Name       | Type                   | Default                          | Description                                                           |
+| ---------- | ---------------------- | -------------------------------- | --------------------------------------------------------------------- |
+| `files`    | `string[]`             | `[]`                             | Files to be scanned, can be an entry into an app or individual files. |
+| `reporter` | [`Reporter`][Reporter] | `{ type: 'json', details 'raw }` | Reporter to use for output.                                           |
 
 [Reporter]: ./src/entities/coscan.ts#L4

--- a/packages/coscan/README.md
+++ b/packages/coscan/README.md
@@ -20,9 +20,9 @@ coscan({
 
 ## Configuration
 
-| Name       | Type                   | Default                          | Description                                                           |
-| ---------- | ---------------------- | -------------------------------- | --------------------------------------------------------------------- |
-| `files`    | `string[]`             | `[]`                             | Files to be scanned, can be an entry into an app or individual files. |
-| `reporter` | [`Reporter`][Reporter] | `{ type: 'json', detail: 'raw }` | Reporter to use for output.                                           |
+| Name       | Type                   | Default                           | Description                                                           |
+| ---------- | ---------------------- | --------------------------------- | --------------------------------------------------------------------- |
+| `files`    | `string[]`             | `[]`                              | Files to be scanned, can be an entry into an app or individual files. |
+| `reporter` | [`Reporter`][Reporter] | `{ type: 'json', detail: 'raw' }` | Reporter to use for output.                                           |
 
 [Reporter]: ./src/entities/coscan.ts#L4

--- a/packages/coscan/src/entities/coscan.ts
+++ b/packages/coscan/src/entities/coscan.ts
@@ -1,9 +1,9 @@
-import { jsonReporter, JsonReporterConfig } from '@coscan/json-reporter';
+import { JsonReporter, jsonReporter } from '@coscan/json-reporter';
 import { jsxScanner } from '@coscan/jsx-scanner';
 
-type Reporter = JsonReporterConfig;
+type Reporter = JsonReporter;
 
-const DEFAULT_REPORTER: Reporter = {
+const DEFAULT_REPORTER: JsonReporter = {
   type: 'json',
   detail: 'raw',
 };
@@ -20,6 +20,6 @@ export async function coscan({ files, reporter = DEFAULT_REPORTER }: CoscanConfi
   });
 
   if (reporter.type === 'json') {
-    return jsonReporter(discoveries, reporter);
+    return jsonReporter(discoveries, { detail: reporter.detail });
   }
 }

--- a/packages/json-reporter/README.md
+++ b/packages/json-reporter/README.md
@@ -22,7 +22,7 @@ async function main() {
     files: ['src/app.tsx'],
   });
 
-  return jsonReporter(discoveries, { type: 'json', details: 'raw' });
+  return jsonReporter(discoveries, { details: 'raw' });
 }
 
 const output = main();

--- a/packages/json-reporter/src/main.ts
+++ b/packages/json-reporter/src/main.ts
@@ -1,1 +1,1 @@
-export { jsonReporter, type JsonReporterConfig } from './reporter.ts';
+export { type JsonReporter, jsonReporter } from './reporter.ts';

--- a/packages/json-reporter/src/reporter.ts
+++ b/packages/json-reporter/src/reporter.ts
@@ -30,8 +30,11 @@ type CountItem = {
 
 type JsonReport = RawItem[] | CountItem[];
 
-export type JsonReporterConfig = {
+export type JsonReporter = {
   type: 'json';
+} & JsonReporterConfig;
+
+export type JsonReporterConfig = {
   detail?: 'raw' | 'count';
 };
 


### PR DESCRIPTION
This will simplify `json-reporter`'s configuration so we no longer need to also pass a `type` as it ends up being redundant.