### PR TITLE
Use path to resolve file paths

### DIFF
--- a/examples/react-simple-example/output.js
+++ b/examples/react-simple-example/output.js
@@ -4,9 +4,7 @@ import { writeFile } from 'node:fs/promises';
 async function main() {
   const results = await coscan({
     files: [
-      'src/components/hello-component.tsx',
-      'src/components/simple-component.tsx',
-      'src/components/entry-component.tsx',
+      'src/entry.tsx',
     ],
     reporter: {
       type: 'json',

--- a/examples/react-simple-example/src/entry.tsx
+++ b/examples/react-simple-example/src/entry.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+import { Hello } from './components/hello-component.tsx';
+import {
+  AnotherComponent,
+  ArrowComponent,
+  Example,
+  ExpressionComponent,
+  SimpleComponent,
+} from './components/simple-component.tsx';
+
+export function App() {
+  return (
+    <>
+      <ExpressionComponent />
+      <ArrowComponent />
+      <SimpleComponent disabled={true} />
+      <Example />
+      <Hello />
+      <SimpleComponent disabled key="1" />
+      <AnotherComponent key="2" />
+    </>
+  );
+}

--- a/packages/coscan/src/entities/coscan.ts
+++ b/packages/coscan/src/entities/coscan.ts
@@ -14,7 +14,10 @@ export type CoscanConfig = {
   reporter?: Reporter;
 };
 
-export async function coscan({ files, reporter = DEFAULT_REPORTER }: CoscanConfig) {
+export async function coscan({
+  files,
+  reporter = DEFAULT_REPORTER,
+}: CoscanConfig) {
   const discoveries = await jsxScanner({
     files,
   });

--- a/packages/jsx-scanner/src/entities/file.test.ts
+++ b/packages/jsx-scanner/src/entities/file.test.ts
@@ -1,6 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
-import { createSourceFile } from 'typescript';
+import { createSourceFile, ScriptTarget } from 'typescript';
 import { getRelativeFilePath } from './file.ts';
+
+const DEFAULT_OPTIONS = ['export const hello = "world"', ScriptTarget.ESNext] as const;
 
 describe(getRelativeFilePath, () => {
   beforeAll(() => {
@@ -11,15 +13,21 @@ describe(getRelativeFilePath, () => {
     jest.restoreAllMocks();
   });
 
-  it('returns the relative file path', () => {
-    const sourceFile = createSourceFile('/path/to/project/src/file.ts', 'export const hello = "world"', 1);
+  it('returns the file path if it already is a relative path', () => {
+    const sourceFile = createSourceFile('src/file.ts', ...DEFAULT_OPTIONS);
 
-    expect(getRelativeFilePath(sourceFile)).toBe('src/file.ts');
+    expect(getRelativeFilePath(sourceFile.fileName)).toBe('src/file.ts');
   });
 
-  it('returns the file path if it already is a relative path', () => {
-    const sourceFile = createSourceFile('src/file.ts', 'export const hello = "world"', 1);
+  it('returns the relative file path if it matches the current working directory', () => {
+    const sourceFile = createSourceFile('/path/to/project/src/file.ts', ...DEFAULT_OPTIONS);
 
-    expect(getRelativeFilePath(sourceFile)).toBe('src/file.ts');
+    expect(getRelativeFilePath(sourceFile.fileName)).toBe('src/file.ts');
+  });
+
+  it('returns an absolute path if the current working directory does not match the path', () => {
+    const sourceFile = createSourceFile('/different/path/src/file.ts', ...DEFAULT_OPTIONS);
+
+    expect(getRelativeFilePath(sourceFile.fileName)).toBe('/different/path/src/file.ts');
   });
 });

--- a/packages/jsx-scanner/src/entities/file.ts
+++ b/packages/jsx-scanner/src/entities/file.ts
@@ -1,13 +1,14 @@
-import type { SourceFile } from 'typescript';
+import path from 'node:path';
 
 export type FilePath = string;
+export type Directory = string;
 
-export function getRelativeFilePath(sourceFile: SourceFile): FilePath {
+export function getRelativeFilePath(filePath: FilePath): FilePath {
   const currentWorkingDirectory = process.cwd();
 
-  const relativeFilePath = sourceFile.fileName.startsWith(currentWorkingDirectory)
-    ? sourceFile.fileName.replace(currentWorkingDirectory + '/', '')
-    : sourceFile.fileName;
+  if (filePath.startsWith(currentWorkingDirectory)) {
+    return path.relative(currentWorkingDirectory, filePath);
+  }
 
-  return relativeFilePath;
+  return filePath;
 }

--- a/packages/jsx-scanner/src/entities/scanner.ts
+++ b/packages/jsx-scanner/src/entities/scanner.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import {
   type CompilerOptions,
   createCompilerHost,
@@ -26,18 +27,21 @@ export async function jsxScanner(config: JsxScannerConfig): Promise<JsxScannerDi
   const host = createCompilerHost(compilerOptions);
 
   const program = createProgram(
-    config.files,
+    // Make sure files are resolved to absolute paths
+    config.files.map((file) => path.resolve(file)),
     compilerOptions,
     host,
   );
 
+  const currentDirectory = program.getCurrentDirectory();
   const sourceFiles = program.getSourceFiles();
+  const typeChecker = program.getTypeChecker();
+
   const moduleResolutionCache = createModuleResolutionCache(
-    process.cwd(),
+    currentDirectory,
     host.getCanonicalFileName,
     compilerOptions,
   );
-  const typeChecker = program.getTypeChecker();
 
   sourceFiles.forEach((sourceFile) => {
     // Skip declaration files
@@ -47,11 +51,11 @@ export async function jsxScanner(config: JsxScannerConfig): Promise<JsxScannerDi
 
     // Parse the source file
     const parse = parser({
+      compilerOptions,
       discoveries,
-      sourceFile,
       importCollection,
       moduleResolutionCache,
-      compilerOptions,
+      sourceFile,
       typeChecker,
     });
 

--- a/packages/jsx-scanner/src/parsers/element-parser.ts
+++ b/packages/jsx-scanner/src/parsers/element-parser.ts
@@ -8,20 +8,25 @@ import { getProps } from '../entities/prop.ts';
 import type { JsxScannerDiscovery } from '../entities/scanner.ts';
 
 type ElementParserArgs = {
-  node: JsxElement | JsxSelfClosingElement;
-  importCollection: ImportCollection;
-  sourceFile: SourceFile;
   discoveries: JsxScannerDiscovery[];
+  importCollection: ImportCollection;
+  node: JsxElement | JsxSelfClosingElement;
+  sourceFile: SourceFile;
 };
 
-export function elementParser({ discoveries, node, importCollection, sourceFile }: ElementParserArgs) {
+export function elementParser({
+  discoveries,
+  importCollection,
+  node,
+  sourceFile,
+}: ElementParserArgs) {
   const startPosition = getPosition(node.getStart(sourceFile), sourceFile);
   const endPosition = getPosition(node.getEnd(), sourceFile);
 
   const isSelfClosing = isJsxSelfClosingElement(node);
   const element = isSelfClosing ? node : node.openingElement;
 
-  const relativeFilePath = getRelativeFilePath(sourceFile);
+  const relativeFilePath = getRelativeFilePath(sourceFile.fileName);
   const positionPath = getPositionPath(startPosition, relativeFilePath);
 
   const componentName: ComponentName = element.tagName.getText(sourceFile);

--- a/packages/jsx-scanner/src/parsers/fragment-parser.ts
+++ b/packages/jsx-scanner/src/parsers/fragment-parser.ts
@@ -7,16 +7,21 @@ import type { JsxScannerDiscovery } from '../entities/scanner.ts';
 
 type FragmentParserArgs = {
   discoveries: JsxScannerDiscovery[];
-  node: JsxFragment;
   importCollection: ImportCollection;
+  node: JsxFragment;
   sourceFile: SourceFile;
 };
 
-export function fragmentParser({ node, sourceFile, importCollection, discoveries }: FragmentParserArgs) {
+export function fragmentParser({
+  discoveries,
+  importCollection,
+  node,
+  sourceFile,
+}: FragmentParserArgs) {
   const startPosition = getPosition(node.getStart(sourceFile), sourceFile);
   const endPosition = getPosition(node.getEnd(), sourceFile);
 
-  const relativeFilePath = getRelativeFilePath(sourceFile);
+  const relativeFilePath = getRelativeFilePath(sourceFile.fileName);
   const positionPath = getPositionPath(startPosition, relativeFilePath);
 
   const componentName: ComponentName = 'Fragment';

--- a/packages/jsx-scanner/src/parsers/function-parser.ts
+++ b/packages/jsx-scanner/src/parsers/function-parser.ts
@@ -38,21 +38,21 @@ function getReturnType(
 }
 
 type FunctionParserArgs = {
+  discoveries: JsxScannerDiscovery[];
+  givenName?: Identifier | BindingName;
+  importCollection: ImportCollection;
   node: FunctionNode;
   sourceFile: SourceFile;
   typeChecker: TypeChecker;
-  givenName?: Identifier | BindingName;
-  importCollection: ImportCollection;
-  discoveries: JsxScannerDiscovery[];
 };
 
 export function functionParser({
+  discoveries,
+  givenName,
+  importCollection,
   node,
   sourceFile,
   typeChecker,
-  givenName,
-  importCollection,
-  discoveries,
 }: FunctionParserArgs) {
   const returnType = getReturnType(node, sourceFile, typeChecker);
 
@@ -61,7 +61,7 @@ export function functionParser({
   const startPosition = getPosition(node.getStart(sourceFile), sourceFile);
   const endPosition = getPosition(node.getEnd(), sourceFile);
 
-  const relativeFilePath = getRelativeFilePath(sourceFile);
+  const relativeFilePath = getRelativeFilePath(sourceFile.fileName);
   const positionPath = getPositionPath(startPosition, relativeFilePath);
 
   const componentName = givenName?.getText(sourceFile) ?? '';

--- a/packages/jsx-scanner/src/parsers/import-parser.ts
+++ b/packages/jsx-scanner/src/parsers/import-parser.ts
@@ -6,24 +6,24 @@ import {
   type SourceFile,
   type System,
 } from 'typescript';
-import { FilePath } from '../entities/file.ts';
+import { type FilePath, getRelativeFilePath } from '../entities/file.ts';
 import { type ImportCollection, ImportPath } from '../entities/import.ts';
 
 type ImportParserArgs = {
-  node: ImportClause;
-  sourceFile: SourceFile;
+  compilerOptions: CompilerOptions;
   importCollection: ImportCollection;
   moduleResolutionCache: ModuleResolutionCache;
-  compilerOptions: CompilerOptions;
+  node: ImportClause;
+  sourceFile: SourceFile;
   system: System;
 };
 
 export function importParser({
-  node,
-  sourceFile,
+  compilerOptions,
   importCollection,
   moduleResolutionCache,
-  compilerOptions,
+  node,
+  sourceFile,
   system,
 }: ImportParserArgs) {
   const importedFrom = node.parent?.moduleSpecifier
@@ -43,7 +43,7 @@ export function importParser({
 
   const resolvedImportPath: ImportPath = resolvedModule.isExternalLibraryImport
     ? importedFrom
-    : resolvedModule.resolvedFileName;
+    : getRelativeFilePath(resolvedModule.resolvedFileName);
 
   if (node.name) {
     const name = node.name.getText(sourceFile);

--- a/packages/jsx-scanner/src/parsers/parser.ts
+++ b/packages/jsx-scanner/src/parsers/parser.ts
@@ -31,56 +31,73 @@ export type ParserArgs = {
 };
 
 export function parser({
-  sourceFile,
+  compilerOptions,
+  discoveries,
   importCollection,
   moduleResolutionCache,
-  compilerOptions,
+  sourceFile,
   typeChecker,
-  discoveries,
 }: ParserArgs) {
   return (node: Node) => {
     if (isFunctionDeclaration(node)) {
-      functionParser({ discoveries, importCollection, node, sourceFile, typeChecker, givenName: node.name });
+      functionParser({
+        discoveries,
+        givenName: node.name,
+        importCollection,
+        node,
+        sourceFile,
+        typeChecker,
+      });
     }
 
     if (isVariableDeclaration(node) && node.initializer) {
       if (isFunctionExpression(node.initializer) || isArrowFunction(node.initializer)) {
         functionParser({
           discoveries,
+          givenName: node.name,
           importCollection,
           node: node.initializer,
           sourceFile,
           typeChecker,
-          givenName: node.name,
         });
       }
     }
 
     if (isJsxElement(node) || isJsxSelfClosingElement(node)) {
-      elementParser({ discoveries, importCollection, node, sourceFile });
+      elementParser({
+        discoveries,
+        importCollection,
+        node,
+        sourceFile,
+      });
     }
 
     if (isJsxFragment(node)) {
-      fragmentParser({ discoveries, importCollection, node, sourceFile });
+      fragmentParser({
+        discoveries,
+        importCollection,
+        node,
+        sourceFile,
+      });
     }
 
     if (isImportClause(node)) {
       importParser({
+        compilerOptions,
         importCollection,
+        moduleResolutionCache,
         node,
         sourceFile,
-        moduleResolutionCache,
-        compilerOptions,
         system,
       });
     }
 
     const parse = parser({
+      compilerOptions,
       discoveries,
-      sourceFile,
       importCollection,
       moduleResolutionCache,
-      compilerOptions,
+      sourceFile,
       typeChecker,
     });
 


### PR DESCRIPTION
This will:
- Move to using `node:path`'s `resolve` to resolve absolute paths of `files`
- Move to using `node:path`'s `relative` to get the relative paths instead of using a custom function
