### PR TITLE
Set up Rollup configuration for CLI

### DIFF
--- a/devtools/rollup/package.json
+++ b/devtools/rollup/package.json
@@ -5,7 +5,9 @@
   "author": "Philip Bordallo",
   "license": "MIT",
   "type": "module",
-  "main": "./src/main.ts",
+  "entry": {
+    "main": "./src/main.ts"
+  },
   "exports": {
     ".": {
       "import": "./dist/main.js",

--- a/devtools/rollup/rollup.config.js
+++ b/devtools/rollup/rollup.config.js
@@ -4,7 +4,7 @@ import { defineConfig } from 'rollup';
 import pkg from './package.json' with { type: 'json' };
 
 export default defineConfig({
-  input: pkg.main,
+  input: pkg.entry.main,
   output: [
     {
       file: pkg.exports['.'].import,

--- a/packages/coscan/package.json
+++ b/packages/coscan/package.json
@@ -4,7 +4,9 @@
   "author": "Philip Bordallo",
   "license": "MIT",
   "type": "module",
-  "main": "./src/main.ts",
+  "entry": {
+    "main": "./src/main.ts"
+  },
   "exports": {
     ".": {
       "import": "./dist/main.js",

--- a/packages/json-reporter/package.json
+++ b/packages/json-reporter/package.json
@@ -4,7 +4,9 @@
   "author": "Philip Bordallo",
   "license": "MIT",
   "type": "module",
-  "main": "./src/main.ts",
+  "entry": {
+    "main": "./src/main.ts"
+  },
   "exports": {
     ".": {
       "import": "./dist/main.js",

--- a/packages/jsx-scanner/package.json
+++ b/packages/jsx-scanner/package.json
@@ -4,7 +4,9 @@
   "author": "Philip Bordallo",
   "license": "MIT",
   "type": "module",
-  "main": "./src/main.ts",
+  "entry": {
+    "main": "./src/main.ts"
+  },
   "exports": {
     ".": {
       "import": "./dist/main.js",


### PR DESCRIPTION
This will:
- Add CLI export for Rollup
- Move from using [`main` property](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#main) to an `entry` property