### PR TITLE
Update publish config

### DIFF
--- a/packages/json-reporter/package.json
+++ b/packages/json-reporter/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "author": "Philip Bordallo",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "entry": {
     "main": "./src/main.ts"

--- a/packages/jsx-scanner/package.json
+++ b/packages/jsx-scanner/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "author": "Philip Bordallo",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "entry": {
     "main": "./src/main.ts"


### PR DESCRIPTION
This will set the [`publishConfig`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#publishconfig) `access` to be `public` for scoped packages.