### PR TITLE
Add bin field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7956,6 +7956,9 @@
         "meow": "^13.2.0",
         "ora": "^8.1.0"
       },
+      "bin": {
+        "coscan": "dist/cli.js"
+      },
       "devDependencies": {
         "@coscan/rollup": "*"
       }

--- a/packages/coscan/package.json
+++ b/packages/coscan/package.json
@@ -22,6 +22,7 @@
       "types": "./dist/main.d.ts"
     }
   },
+  "bin": "./dist/cli.js",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
This will add [`bin` field](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#bin) for `coscan` so that it can be correctly installed as an executable 