### PR TITLE
Add parser for class components

### DIFF
--- a/examples/react-simple-example/src/components/class-component.tsx
+++ b/examples/react-simple-example/src/components/class-component.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+export const ClassExpressionComponent = class extends React.Component {
+  render() {
+    return <div />;
+  }
+};
+
+export class ClassDeclarationComponent extends React.Component {
+  render() {
+    return <div />;
+  }
+}
+
+export default class extends React.Component {
+  render() {
+    return <div />;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "clean": "turbo run clean",
     "publish": "npm run build && npm run test && npm publish -w packages",
     "test": "jest",
-    "version": "npm version -w packages",
-    "example": "node packages/coscan/dist/cli.js examples/react-simple-example/src/components/class-component.tsx"
+    "version": "npm version -w packages"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "clean": "turbo run clean",
     "publish": "npm run build && npm run test && npm publish -w packages",
     "test": "jest",
-    "version": "npm version -w packages"
+    "version": "npm version -w packages",
+    "example": "node packages/coscan/dist/cli.js examples/react-simple-example/src/components/class-component.tsx"
   }
 }

--- a/packages/jsx-scanner/src/parsers/class-parser.ts
+++ b/packages/jsx-scanner/src/parsers/class-parser.ts
@@ -1,0 +1,64 @@
+import {
+  type ClassLikeDeclaration,
+  type HeritageClause,
+  type Identifier,
+  type NodeArray,
+  type SourceFile,
+} from 'typescript';
+import { type ComponentDefinition, getComponentId } from '../entities/component.ts';
+import { getRelativeFilePath } from '../entities/file.ts';
+import type { ImportCollection } from '../entities/import.ts';
+import { getPosition, getPositionPath } from '../entities/position.ts';
+import type { JsxScannerDiscovery } from '../entities/scanner.ts';
+
+const REACT_BASE_CLASSES = ['React.Component', 'React.PureComponent', 'Component', 'PureComponent'];
+
+function isReactComponentDescendant(heritageClauses: NodeArray<HeritageClause>, sourceFile?: SourceFile): boolean {
+  const heritageExpressions = heritageClauses.flatMap((clause) =>
+    clause.types.map((type) => type.expression.getText(sourceFile))
+  );
+
+  return heritageExpressions.some((expression) => REACT_BASE_CLASSES.includes(expression));
+}
+
+type ClassParserArgs = {
+  discoveries: JsxScannerDiscovery[];
+  givenName?: Identifier;
+  importCollection: ImportCollection;
+  node: ClassLikeDeclaration;
+  sourceFile: SourceFile;
+};
+
+export function classParser({
+  discoveries,
+  givenName,
+  importCollection,
+  node,
+  sourceFile,
+}: ClassParserArgs) {
+  // Ignore classes that don't have a lineage or aren't descendants of React.Component or React.PureComponent
+  if (!node.heritageClauses || !isReactComponentDescendant(node.heritageClauses, sourceFile)) {
+    return;
+  }
+
+  const startPosition = getPosition(node.getStart(), sourceFile);
+  const endPosition = getPosition(node.getEnd(), sourceFile);
+
+  const relativeFilePath = getRelativeFilePath(sourceFile.fileName);
+  const positionPath = getPositionPath(startPosition, relativeFilePath);
+
+  const componentName = givenName?.getText(sourceFile) ?? '';
+  const componentId = getComponentId(componentName, importCollection, relativeFilePath);
+
+  const definition: ComponentDefinition = {
+    type: 'definition',
+    componentName,
+    componentId,
+    filePath: relativeFilePath,
+    location: positionPath,
+    startPosition,
+    endPosition,
+  };
+
+  discoveries.push(definition);
+}

--- a/packages/jsx-scanner/src/parsers/class-parser.ts
+++ b/packages/jsx-scanner/src/parsers/class-parser.ts
@@ -70,8 +70,6 @@ export function classParser({
     location: positionPath,
     startPosition,
     endPosition,
-    // @ts-ignore
-    props: props,
   };
 
   discoveries.push(definition);

--- a/packages/jsx-scanner/src/parsers/class-parser.ts
+++ b/packages/jsx-scanner/src/parsers/class-parser.ts
@@ -13,9 +13,6 @@ import type { JsxScannerDiscovery } from '../entities/scanner.ts';
 
 const REACT_BASE_CLASSES = ['Component', 'PureComponent'];
 
-type PropString = `${string}: ${string};` | `${string}: ${string},` | string & {};
-type Props = Record<string, unknown>;
-
 function getClassType(
   expressions: ExpressionWithTypeArguments[],
   typeChecker: TypeChecker,

--- a/packages/jsx-scanner/src/parsers/parser.test.ts
+++ b/packages/jsx-scanner/src/parsers/parser.test.ts
@@ -263,4 +263,20 @@ describe(parser, () => {
       disabled: true,
     });
   });
+
+  it('works with class components', () => {
+    const output = renderWithConfig(`
+      import React from 'react';
+      class App extends React.Component {
+        render() {
+          return <div>Hello, world!</div>;
+        }
+      }
+    `);
+
+    const parse = parser(output);
+    parse(output.sourceFile);
+
+    expect(output.discoveries).toHaveLength(2);
+  });
 });

--- a/packages/jsx-scanner/src/parsers/parser.ts
+++ b/packages/jsx-scanner/src/parsers/parser.ts
@@ -1,8 +1,12 @@
 import {
   type CompilerOptions,
   isArrowFunction,
+  isClassDeclaration,
+  isClassExpression,
+  isClassLike,
   isFunctionDeclaration,
   isFunctionExpression,
+  isIdentifier,
   isImportClause,
   isJsxElement,
   isJsxFragment,
@@ -16,6 +20,7 @@ import {
 } from 'typescript';
 import { type ImportCollection } from '../entities/import.ts';
 import { type JsxScannerDiscovery } from '../entities/scanner.ts';
+import { classParser } from './class-parser.ts';
 import { elementParser } from './element-parser.ts';
 import { fragmentParser } from './fragment-parser.ts';
 import { functionParser } from './function-parser.ts';
@@ -61,6 +66,21 @@ export function parser({
           typeChecker,
         });
       }
+    }
+
+    if (isClassLike(node)) {
+      // If class is an expression, get parent node to determine given name
+      const givenName = isClassExpression(node) && isVariableDeclaration(node.parent) && isIdentifier(node.parent.name)
+        ? node.parent.name
+        : node.name;
+
+      classParser({
+        discoveries,
+        givenName,
+        importCollection,
+        node,
+        sourceFile,
+      });
     }
 
     if (isJsxElement(node) || isJsxSelfClosingElement(node)) {

--- a/packages/jsx-scanner/src/parsers/parser.ts
+++ b/packages/jsx-scanner/src/parsers/parser.ts
@@ -69,7 +69,7 @@ export function parser({
     }
 
     if (isClassLike(node)) {
-      // If class is an expression, get parent node to determine given name
+      // If node is a class expression, get parent node to determine given name
       const givenName = isClassExpression(node) && isVariableDeclaration(node.parent) && isIdentifier(node.parent.name)
         ? node.parent.name
         : node.name;
@@ -80,6 +80,7 @@ export function parser({
         importCollection,
         node,
         sourceFile,
+        typeChecker,
       });
     }
 


### PR DESCRIPTION
This will:
- Parse class components that extend `React.Component` and `React.PureComponent`
- Use typeChecker to gets types instead of relying on specifically named strings as they always can be renamed