### PR TITLE
Handle sub components and their parts

### DIFF
--- a/examples/react-fixtures/src/components/import-component.tsx
+++ b/examples/react-fixtures/src/components/import-component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { ButtonComponent } from './button-component.tsx';
+import { ButtonComponent as Button } from './button-component.tsx';
 
 export function ImportComponent() {
-  return <ButtonComponent>Hello</ButtonComponent>;
+  return <Button>Hello</Button>;
 }

--- a/examples/react-fixtures/src/components/no-component.tsx
+++ b/examples/react-fixtures/src/components/no-component.tsx
@@ -5,3 +5,7 @@ export function add(a: number, b: number): number {
 export class Example {}
 
 export class Child extends Example {}
+
+export const assignment = Object.assign(add, {
+  value: 3,
+});

--- a/examples/react-fixtures/src/components/sub-components.tsx
+++ b/examples/react-fixtures/src/components/sub-components.tsx
@@ -1,0 +1,12 @@
+import { Table } from './table-component';
+
+export function ExampleTable() {
+  return (
+    <Table>
+      <Table.Row>
+        <Table.Cell>Cell 1</Table.Cell>
+        <Table.Cell>Cell 2</Table.Cell>
+      </Table.Row>
+    </Table>
+  );
+}

--- a/examples/react-fixtures/src/components/table-component.tsx
+++ b/examples/react-fixtures/src/components/table-component.tsx
@@ -1,0 +1,32 @@
+type TableProps = {
+  children: React.ReactNode;
+};
+
+function TableRoot(props: TableProps) {
+  return (
+    <table>
+      {props.children}
+    </table>
+  );
+}
+
+function Row(props: TableProps) {
+  return (
+    <tr>
+      {props.children}
+    </tr>
+  );
+}
+
+function Cell(props: TableProps) {
+  return (
+    <td>
+      {props.children}
+    </td>
+  );
+}
+
+export const Table = Object.assign(TableRoot, {
+  Row,
+  Cell,
+});

--- a/packages/jsx-scanner/src/entities/component.test.ts
+++ b/packages/jsx-scanner/src/entities/component.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import { getComponentId } from './component.ts';
+import { getComponentId, getParentName } from './component.ts';
 import type { ImportCollection } from './import.ts';
 
 jest.mock('./unique-id.ts', () => ({
-  createUniqueId() {
+  createUniqueId(value: string) {
+    if (value === 'div') return 2;
+    if (value === 'svg') return 3;
+    if (value === './example.ts:Example') return 4;
+    if (value === 'library:Button') return 5;
+    if (value === './file.ts:FileComponent') return 6;
+    if (value === 'library:Table.Body') return 7;
     return 1;
   },
 }));
@@ -11,21 +17,41 @@ jest.mock('./unique-id.ts', () => ({
 describe(getComponentId, () => {
   const importCollection: ImportCollection = new Map([
     ['Example', './example.ts'],
+    ['Button', 'library'],
+    ['Table', 'library'],
   ]);
 
   it('returns a unique id for a built-in HTML component', () => {
-    expect(getComponentId('div', importCollection, './file.ts')).toBe('html:1');
+    expect(getComponentId('div', importCollection, './file.ts')).toBe('html:2');
   });
 
   it('returns a unique id for a built-in SVG component', () => {
-    expect(getComponentId('svg', importCollection, './file.ts')).toBe('svg:1');
+    expect(getComponentId('svg', importCollection, './file.ts')).toBe('svg:3');
   });
 
-  it('returns a unique id for a component from an import', () => {
-    expect(getComponentId('Example', importCollection, './file.ts')).toBe('jsx:1');
+  it('returns a unique id for a component from a local import', () => {
+    expect(getComponentId('Example', importCollection, './file.ts')).toBe('jsx:4');
+  });
+
+  it('returns a unique id for a component from a package import', () => {
+    expect(getComponentId('Button', importCollection, './file.ts')).toBe('jsx:5');
   });
 
   it('returns a unique id for a component from a file path', () => {
-    expect(getComponentId('FileComponent', importCollection, './file.ts')).toBe('jsx:1');
+    expect(getComponentId('FileComponent', importCollection, './file.ts')).toBe('jsx:6');
+  });
+
+  it('returns a unique id for a sub component using an import', () => {
+    expect(getComponentId('Table.Body', importCollection, './file.ts')).toBe('jsx:7');
+  });
+});
+
+describe(getParentName, () => {
+  it('returns a parent name when the name has subparts', () => {
+    expect(getParentName('Table.Header')).toBe('Table');
+  });
+
+  it('returns undefined when the name does not have sub parts', () => {
+    expect(getParentName('Table')).toBeUndefined();
   });
 });

--- a/packages/jsx-scanner/src/entities/component.ts
+++ b/packages/jsx-scanner/src/entities/component.ts
@@ -37,7 +37,8 @@ export function getComponentId(
   importCollection: ImportCollection,
   filePath: FilePath,
 ): ComponentId {
-  const importPath = importCollection.get(name);
+  const importName = getParentName(name) ?? name;
+  const importPath = importCollection.get(importName);
 
   if (isBuiltInHtml(name)) {
     const id = createUniqueId(name);
@@ -56,4 +57,18 @@ export function getComponentId(
 
   const id = createUniqueId(`${filePath}:${name}`);
   return `jsx:${id}`;
+}
+
+/** If a name has subparts, get the parent name.
+ *
+ * @example `Table.Header` -> `Table`
+ */
+export function getParentName(name: string): string | undefined {
+  if (name.includes('.')) {
+    const [parent] = name.split('.');
+
+    return parent;
+  }
+
+  return undefined;
 }

--- a/packages/jsx-scanner/src/entities/component.ts
+++ b/packages/jsx-scanner/src/entities/component.ts
@@ -37,8 +37,8 @@ export function getComponentId(
   importCollection: ImportCollection,
   filePath: FilePath,
 ): ComponentId {
-  const importName = getParentName(name) ?? name;
-  const importPath = importCollection.get(importName);
+  const parentName = getParentName(name);
+  const importPath = importCollection.get(parentName ?? name);
 
   if (isBuiltInHtml(name)) {
     const id = createUniqueId(name);

--- a/packages/jsx-scanner/src/entities/scanner.test.ts
+++ b/packages/jsx-scanner/src/entities/scanner.test.ts
@@ -162,7 +162,7 @@ const tests: Test[] = [
       expect(instances).toHaveLength(1);
 
       const importComponent = instances[0];
-      expect(importComponent.componentName).toBe('ButtonComponent');
+      expect(importComponent.componentName).toBe('Button');
     },
   },
 ];

--- a/packages/jsx-scanner/src/entities/scanner.test.ts
+++ b/packages/jsx-scanner/src/entities/scanner.test.ts
@@ -165,6 +165,56 @@ const tests: Test[] = [
       expect(importComponent.componentName).toBe('Button');
     },
   },
+  {
+    it: 'works with sub-component instances',
+    filePath: 'examples/react-fixtures/src/components/sub-components.tsx',
+    test: async (results) => {
+      const instances = results.filter((result) => result.type === 'instance');
+      expect(instances).toHaveLength(4);
+
+      const table = instances[0];
+      expect(table.componentName).toBe('Table');
+      expect(table.importedFrom).toBe('examples/react-fixtures/src/components/table-component.tsx');
+
+      const row = instances[1];
+      expect(row.componentName).toBe('Table.Row');
+      expect(row.importedFrom).toBe('examples/react-fixtures/src/components/table-component.tsx');
+
+      const cell1 = instances[2];
+      expect(cell1.componentName).toBe('Table.Cell');
+      expect(cell1.importedFrom).toBe('examples/react-fixtures/src/components/table-component.tsx');
+
+      const cell2 = instances[3];
+      expect(cell2.componentName).toBe('Table.Cell');
+      expect(cell2.importedFrom).toBe('examples/react-fixtures/src/components/table-component.tsx');
+    },
+  },
+  {
+    it: 'works with sub-component definitions',
+    filePath: 'examples/react-fixtures/src/components/table-component.tsx',
+    test: async (results) => {
+      const definitions = results.filter((result) => result.type === 'definition');
+      expect(definitions).toHaveLength(6);
+
+      const tableRoot = definitions[0];
+      expect(tableRoot.componentName).toBe('TableRoot');
+
+      const row = definitions[1];
+      expect(row.componentName).toBe('Row');
+
+      const cell = definitions[2];
+      expect(cell.componentName).toBe('Cell');
+
+      const table = definitions[3];
+      expect(table.componentName).toBe('Table');
+
+      const tableRow = definitions[4];
+      expect(tableRow.componentName).toBe('Table.Row');
+
+      const tableCell = definitions[5];
+      expect(tableCell.componentName).toBe('Table.Cell');
+    },
+  },
 ];
 
 describe(jsxScanner, () => {

--- a/packages/jsx-scanner/src/guards/element-return.ts
+++ b/packages/jsx-scanner/src/guards/element-return.ts
@@ -1,6 +1,6 @@
 export type ElementReturn = 'ReactElement' | 'ReactNode' | 'React.JSX.Element' | 'JSX.Element' | 'Element';
 
-export function isElementReturn(returnType: string): returnType is ElementReturn {
+export function isElementReturn(returnType: string | undefined): returnType is ElementReturn {
   switch (returnType) {
     case 'ReactElement':
     case 'ReactNode':

--- a/packages/jsx-scanner/src/parsers/assign-parser.ts
+++ b/packages/jsx-scanner/src/parsers/assign-parser.ts
@@ -74,9 +74,9 @@ export function assignParser({
     }
   });
 
-  Object.entries(parts).forEach(([partName, parNode]) => {
-    const startPosition = getPosition(parNode.getStart(sourceFile), sourceFile);
-    const endPosition = getPosition(parNode.getEnd(), sourceFile);
+  Object.entries(parts).forEach(([partName, partNode]) => {
+    const startPosition = getPosition(partNode.getStart(sourceFile), sourceFile);
+    const endPosition = getPosition(partNode.getEnd(), sourceFile);
 
     const relativeFilePath = getRelativeFilePath(sourceFile.fileName);
     const positionPath = getPositionPath(startPosition, relativeFilePath);

--- a/packages/jsx-scanner/src/parsers/assign-parser.ts
+++ b/packages/jsx-scanner/src/parsers/assign-parser.ts
@@ -1,0 +1,99 @@
+import {
+  type BindingName,
+  type CallExpression,
+  isIdentifier,
+  isObjectLiteralExpression,
+  type Node,
+  SignatureKind,
+  type SourceFile,
+  type TypeChecker,
+} from 'typescript';
+import { type ComponentDefinition, type ComponentName, getComponentId } from '../entities/component.ts';
+import { getRelativeFilePath } from '../entities/file.ts';
+import type { ImportCollection } from '../entities/import.ts';
+import { getPosition, getPositionPath } from '../entities/position.ts';
+import type { JsxScannerDiscovery } from '../entities/scanner.ts';
+import { isElementReturn } from '../guards/element-return.ts';
+
+function isComponentDefinition(node: Node, typeChecker: TypeChecker) {
+  const nodeType = typeChecker.getTypeAtLocation(node);
+  const signatures = typeChecker.getSignaturesOfType(nodeType, SignatureKind.Call);
+
+  if (signatures.length) {
+    const returnType = typeChecker.getReturnTypeOfSignature(signatures[0]);
+    const returnTypeString = typeChecker.typeToString(returnType);
+
+    return isElementReturn(returnTypeString);
+  }
+
+  return false;
+}
+
+type AssignParserArgs = {
+  discoveries: JsxScannerDiscovery[];
+  givenName: BindingName;
+  importCollection: ImportCollection;
+  node: CallExpression;
+  sourceFile: SourceFile;
+  typeChecker: TypeChecker;
+};
+
+export function assignParser({
+  discoveries,
+  givenName,
+  importCollection,
+  node,
+  sourceFile,
+  typeChecker,
+}: AssignParserArgs) {
+  // If node expressions is not `Object.assign`, skip
+  const expression = node.expression.getText(sourceFile);
+  if (expression !== 'Object.assign') return;
+
+  const parts: Record<string, Node> = {};
+
+  node.arguments.forEach((argument) => {
+    const namespace = givenName.getText(sourceFile);
+
+    // If argument is the parent component, example `Table`
+    if (isIdentifier(argument)) {
+      if (isComponentDefinition(argument, typeChecker)) {
+        parts[namespace] = argument;
+      }
+    }
+
+    // If property is a sub component, example `Table.Row`
+    if (isObjectLiteralExpression(argument)) {
+      argument.properties.forEach((property) => {
+        const subName = `${namespace}.${property.getText()}`;
+
+        if (isComponentDefinition(property, typeChecker)) {
+          parts[subName] = property;
+        }
+      });
+    }
+  });
+
+  Object.entries(parts).forEach(([partName, parNode]) => {
+    const startPosition = getPosition(parNode.getStart(sourceFile), sourceFile);
+    const endPosition = getPosition(parNode.getEnd(), sourceFile);
+
+    const relativeFilePath = getRelativeFilePath(sourceFile.fileName);
+    const positionPath = getPositionPath(startPosition, relativeFilePath);
+
+    const componentName: ComponentName = partName;
+    const componentId = getComponentId(componentName, importCollection, relativeFilePath);
+
+    const definition: ComponentDefinition = {
+      type: 'definition',
+      componentName,
+      componentId,
+      filePath: relativeFilePath,
+      location: positionPath,
+      startPosition,
+      endPosition,
+    };
+
+    discoveries.push(definition);
+  });
+}

--- a/packages/jsx-scanner/src/parsers/element-parser.ts
+++ b/packages/jsx-scanner/src/parsers/element-parser.ts
@@ -1,5 +1,5 @@
 import { isJsxSelfClosingElement, type JsxElement, type JsxSelfClosingElement, type SourceFile } from 'typescript';
-import { type ComponentName, getComponentId } from '../entities/component.ts';
+import { type ComponentName, getComponentId, getParentName } from '../entities/component.ts';
 import type { ComponentInstance } from '../entities/component.ts';
 import { getRelativeFilePath } from '../entities/file.ts';
 import type { ImportCollection } from '../entities/import.ts';
@@ -31,14 +31,16 @@ export function elementParser({
 
   const componentName: ComponentName = element.tagName.getText(sourceFile);
   const componentId = getComponentId(componentName, importCollection, relativeFilePath);
+  const parentName = getParentName(componentName);
 
+  const importPath = importCollection.get(parentName ?? componentName);
   const props = getProps(element.attributes, sourceFile);
 
   const instance: ComponentInstance = {
     type: 'instance',
     componentName,
     componentId,
-    importedFrom: importCollection.get(componentName),
+    importedFrom: importPath,
     filePath: relativeFilePath,
     location: positionPath,
     isSelfClosing,

--- a/packages/jsx-scanner/src/parsers/function-parser.ts
+++ b/packages/jsx-scanner/src/parsers/function-parser.ts
@@ -56,7 +56,7 @@ export function functionParser({
 }: FunctionParserArgs) {
   const returnType = getReturnType(node, sourceFile, typeChecker);
 
-  if (!returnType || !isElementReturn(returnType)) return;
+  if (!isElementReturn(returnType)) return;
 
   const startPosition = getPosition(node.getStart(sourceFile), sourceFile);
   const endPosition = getPosition(node.getEnd(), sourceFile);

--- a/packages/jsx-scanner/src/parsers/import-parser.ts
+++ b/packages/jsx-scanner/src/parsers/import-parser.ts
@@ -13,9 +13,9 @@ import { type ImportCollection, ImportPath } from '../entities/import.ts';
 /**
  * Get an aliased import name from a named import binding.
  * @example
- * `import { thing as other } from 'library'` -> 'other'
+ * `thing as other` -> 'other'
  */
-function getAliasedImportName(nameBinding: Node, sourceFile?: SourceFile): string | undefined {
+function getAliasedName(nameBinding: Node, sourceFile?: SourceFile): string | undefined {
   const lastToken = nameBinding.getLastToken(sourceFile);
 
   return lastToken?.getText(sourceFile);
@@ -75,7 +75,7 @@ export function importParser({
    */
   if (node.namedBindings) {
     node.namedBindings.forEachChild((nameBinding) => {
-      const name = getAliasedImportName(nameBinding, sourceFile) ?? nameBinding.getText(sourceFile);
+      const name = getAliasedName(nameBinding, sourceFile) ?? nameBinding.getText(sourceFile);
 
       importCollection.set(name, resolvedImportPath);
     });

--- a/packages/jsx-scanner/src/parsers/import-parser.ts
+++ b/packages/jsx-scanner/src/parsers/import-parser.ts
@@ -10,7 +10,12 @@ import {
 import { type FilePath, getRelativeFilePath } from '../entities/file.ts';
 import { type ImportCollection, ImportPath } from '../entities/import.ts';
 
-function getParentImportName(nameBinding: Node, sourceFile?: SourceFile): string | undefined {
+/**
+ * Get an aliased import name from a named import binding.
+ * @example
+ * `import { thing as other } from 'library'` -> 'other'
+ */
+function getAliasedImportName(nameBinding: Node, sourceFile?: SourceFile): string | undefined {
   const lastToken = nameBinding.getLastToken(sourceFile);
 
   return lastToken?.getText(sourceFile);
@@ -70,7 +75,7 @@ export function importParser({
    */
   if (node.namedBindings) {
     node.namedBindings.forEachChild((nameBinding) => {
-      const name = getParentImportName(nameBinding, sourceFile) ?? nameBinding.getText(sourceFile);
+      const name = getAliasedImportName(nameBinding, sourceFile) ?? nameBinding.getText(sourceFile);
 
       importCollection.set(name, resolvedImportPath);
     });

--- a/packages/jsx-scanner/src/parsers/parser.ts
+++ b/packages/jsx-scanner/src/parsers/parser.ts
@@ -1,6 +1,7 @@
 import {
   type CompilerOptions,
   isArrowFunction,
+  isCallExpression,
   isClassDeclaration,
   isClassExpression,
   isClassLike,
@@ -14,12 +15,14 @@ import {
   isVariableDeclaration,
   type ModuleResolutionCache,
   type Node,
+  SignatureKind,
   type SourceFile,
   sys as system,
   type TypeChecker,
 } from 'typescript';
 import { type ImportCollection } from '../entities/import.ts';
 import { type JsxScannerDiscovery } from '../entities/scanner.ts';
+import { assignParser } from './assign-parser.ts';
 import { classParser } from './class-parser.ts';
 import { elementParser } from './element-parser.ts';
 import { fragmentParser } from './fragment-parser.ts';
@@ -58,6 +61,17 @@ export function parser({
     if (isVariableDeclaration(node) && node.initializer) {
       if (isFunctionExpression(node.initializer) || isArrowFunction(node.initializer)) {
         functionParser({
+          discoveries,
+          givenName: node.name,
+          importCollection,
+          node: node.initializer,
+          sourceFile,
+          typeChecker,
+        });
+      }
+
+      if (isCallExpression(node.initializer)) {
+        assignParser({
           discoveries,
           givenName: node.name,
           importCollection,


### PR DESCRIPTION
This will handle sub components `Table.Body` and make sure that they are marked correctly by the import parser.

Previously the parser was treating each sub component as a local component causing instances not to be grouped together.