### PR TITLE
Rename parent name to namespace

### DIFF
--- a/packages/jsx-scanner/src/entities/component.test.ts
+++ b/packages/jsx-scanner/src/entities/component.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import { getComponentId, getParentName } from './component.ts';
+import { getComponentId } from './component.ts';
 import type { ImportCollection } from './import.ts';
 
 jest.mock('./unique-id.ts', () => ({
@@ -43,15 +43,5 @@ describe(getComponentId, () => {
 
   it('returns a unique id for a sub component using an import', () => {
     expect(getComponentId('Table.Body', importCollection, './file.ts')).toBe('jsx:7');
-  });
-});
-
-describe(getParentName, () => {
-  it('returns a parent name when the name has subparts', () => {
-    expect(getParentName('Table.Header')).toBe('Table');
-  });
-
-  it('returns undefined when the name does not have sub parts', () => {
-    expect(getParentName('Table')).toBeUndefined();
   });
 });

--- a/packages/jsx-scanner/src/entities/component.ts
+++ b/packages/jsx-scanner/src/entities/component.ts
@@ -4,6 +4,7 @@ import { type FilePath } from './file.ts';
 import { type ImportCollection, type ImportPath } from './import.ts';
 import type { Position, PositionPath } from './position.ts';
 import type { Props } from './prop.ts';
+import { getNamespace } from './string.ts';
 import { createUniqueId, type UniqueId } from './unique-id.ts';
 
 export type ComponentId = `${'html' | 'svg' | 'jsx'}:${UniqueId}`;
@@ -37,8 +38,8 @@ export function getComponentId(
   importCollection: ImportCollection,
   filePath: FilePath,
 ): ComponentId {
-  const parentName = getParentName(name);
-  const importPath = importCollection.get(parentName ?? name);
+  const importkey = getNamespace(name) ?? name;
+  const importPath = importCollection.get(importkey);
 
   if (isBuiltInHtml(name)) {
     const id = createUniqueId(name);
@@ -57,18 +58,4 @@ export function getComponentId(
 
   const id = createUniqueId(`${filePath}:${name}`);
   return `jsx:${id}`;
-}
-
-/** If a name has subparts, get the parent name.
- *
- * @example `Table.Header` -> `Table`
- */
-export function getParentName(name: string): string | undefined {
-  if (name.includes('.')) {
-    const [parent] = name.split('.');
-
-    return parent;
-  }
-
-  return undefined;
 }

--- a/packages/jsx-scanner/src/entities/string.test.ts
+++ b/packages/jsx-scanner/src/entities/string.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from '@jest/globals';
+import { getNamespace } from './string.ts';
+
+describe(getNamespace, () => {
+  it('returns the namespace when the string has subparts', () => {
+    expect(getNamespace('Table.Header')).toBe('Table');
+  });
+
+  it('returns undefined when the string does not have subparts', () => {
+    expect(getNamespace('Table')).toBeUndefined();
+  });
+});

--- a/packages/jsx-scanner/src/entities/string.ts
+++ b/packages/jsx-scanner/src/entities/string.ts
@@ -1,0 +1,13 @@
+/** If a string has subparts, get the namespace, otherwise return the string itself.
+ *
+ * @example `Table.Header` -> `Table`
+ */
+export function getNamespace(content: string): string | undefined {
+  if (content.includes('.')) {
+    const [namespace] = content.split('.');
+
+    return namespace;
+  }
+
+  return undefined;
+}

--- a/packages/jsx-scanner/src/parsers/element-parser.ts
+++ b/packages/jsx-scanner/src/parsers/element-parser.ts
@@ -1,11 +1,12 @@
 import { isJsxSelfClosingElement, type JsxElement, type JsxSelfClosingElement, type SourceFile } from 'typescript';
-import { type ComponentName, getComponentId, getParentName } from '../entities/component.ts';
+import { type ComponentName, getComponentId } from '../entities/component.ts';
 import type { ComponentInstance } from '../entities/component.ts';
 import { getRelativeFilePath } from '../entities/file.ts';
 import type { ImportCollection } from '../entities/import.ts';
 import { getPosition, getPositionPath } from '../entities/position.ts';
 import { getProps } from '../entities/prop.ts';
 import type { JsxScannerDiscovery } from '../entities/scanner.ts';
+import { getNamespace } from '../entities/string.ts';
 
 type ElementParserArgs = {
   discoveries: JsxScannerDiscovery[];
@@ -31,9 +32,10 @@ export function elementParser({
 
   const componentName: ComponentName = element.tagName.getText(sourceFile);
   const componentId = getComponentId(componentName, importCollection, relativeFilePath);
-  const parentName = getParentName(componentName);
 
-  const importPath = importCollection.get(parentName ?? componentName);
+  const importKey = getNamespace(componentName) ?? componentName;
+  const importPath = importCollection.get(importKey);
+
   const props = getProps(element.attributes, sourceFile);
 
   const instance: ComponentInstance = {


### PR DESCRIPTION
This will rename `getParentName` to `getNamespace` to be a bit more succinct as it relates to strings and whether they have a namespace or parts and less about components having parents.