### PR TITLE
Handle default imports and exports

### DIFF
--- a/packages/jsx-scanner/src/entities/component.test.ts
+++ b/packages/jsx-scanner/src/entities/component.test.ts
@@ -10,15 +10,18 @@ jest.mock('./unique-id.ts', () => ({
     if (value === 'library:Button') return 5;
     if (value === './file.ts:FileComponent') return 6;
     if (value === 'library:Table.Body') return 7;
+    if (value === 'react:default') return 8;
+
     return 1;
   },
 }));
 
 describe(getComponentId, () => {
   const importCollection: ImportCollection = new Map([
-    ['Example', './example.ts'],
-    ['Button', 'library'],
-    ['Table', 'library'],
+    ['Example', { path: './example.ts', isDefault: false }],
+    ['Button', { path: 'library', isDefault: false }],
+    ['Table', { path: 'library', isDefault: false }],
+    ['React', { path: 'react', isDefault: true }],
   ]);
 
   it('returns a unique id for a built-in HTML component', () => {
@@ -43,5 +46,9 @@ describe(getComponentId, () => {
 
   it('returns a unique id for a sub component using an import', () => {
     expect(getComponentId('Table.Body', importCollection, './file.ts')).toBe('jsx:7');
+  });
+
+  it('returns a unique id for a default import', () => {
+    expect(getComponentId('React', importCollection, './file.ts')).toBe('jsx:8');
   });
 });

--- a/packages/jsx-scanner/src/entities/component.ts
+++ b/packages/jsx-scanner/src/entities/component.ts
@@ -39,7 +39,7 @@ export function getComponentId(
   filePath: FilePath,
 ): ComponentId {
   const importkey = getNamespace(name) ?? name;
-  const importPath = importCollection.get(importkey);
+  const importMeta = importCollection.get(importkey);
 
   if (isBuiltInHtml(name)) {
     const id = createUniqueId(name);
@@ -51,8 +51,13 @@ export function getComponentId(
     return `svg:${id}`;
   }
 
-  if (importPath) {
-    const id = createUniqueId(`${importPath}:${name}`);
+  if (importMeta && importMeta.isDefault) {
+    const id = createUniqueId(`${importMeta.path}:default`);
+    return `jsx:${id}`;
+  }
+
+  if (importMeta && !importMeta.isDefault) {
+    const id = createUniqueId(`${importMeta.path}:${name}`);
     return `jsx:${id}`;
   }
 

--- a/packages/jsx-scanner/src/entities/declaration.ts
+++ b/packages/jsx-scanner/src/entities/declaration.ts
@@ -1,0 +1,34 @@
+import {
+  type ClassLikeDeclaration,
+  type FunctionDeclaration,
+  isClassExpression,
+  isVariableDeclaration,
+  type SourceFile,
+  SyntaxKind,
+  type VariableDeclaration,
+} from 'typescript';
+
+export type GivenName = string;
+
+/**
+ * Get the given name of a declaration.
+ */
+export function getGivenName(
+  node: FunctionDeclaration | VariableDeclaration | ClassLikeDeclaration,
+  sourceFile: SourceFile,
+): GivenName {
+  const modifiers = !isVariableDeclaration(node) ? node.modifiers : undefined;
+  const isDefaultExport = modifiers?.some((modifier) => modifier.kind === SyntaxKind.DefaultKeyword);
+
+  // If node is a class expression, get parent node to determine given name
+  const name = isClassExpression(node) && isVariableDeclaration(node.parent)
+    ? node.parent.name
+    : node.name;
+
+  if (isDefaultExport) {
+    return 'default';
+  }
+
+  // If there is no defined name then fallback to an empty string
+  return name?.getText(sourceFile) ?? '';
+}

--- a/packages/jsx-scanner/src/entities/import.ts
+++ b/packages/jsx-scanner/src/entities/import.ts
@@ -1,3 +1,7 @@
 export type Import = string;
 export type ImportPath = string;
-export type ImportCollection = Map<Import, ImportPath>;
+export type ImportMeta = {
+  isDefault: boolean;
+  path: ImportPath;
+};
+export type ImportCollection = Map<Import, ImportMeta>;

--- a/packages/jsx-scanner/src/entities/scanner.test.ts
+++ b/packages/jsx-scanner/src/entities/scanner.test.ts
@@ -48,7 +48,7 @@ const tests: Test[] = [
       expect(declarationComponent.componentName).toBe('ClassDeclarationComponent');
 
       const defaultComponent = definitions[2];
-      expect(defaultComponent.componentName).toBe('');
+      expect(defaultComponent.componentName).toBe('default');
     },
   },
   {
@@ -68,7 +68,7 @@ const tests: Test[] = [
       expect(functionDeclarationComponent.componentName).toBe('FunctionDeclarationComponent');
 
       const defaultComponent = definitions[3];
-      expect(defaultComponent.componentName).toBe('');
+      expect(defaultComponent.componentName).toBe('default');
     },
   },
   {

--- a/packages/jsx-scanner/src/entities/string.ts
+++ b/packages/jsx-scanner/src/entities/string.ts
@@ -1,4 +1,4 @@
-/** If a string has subparts, get the namespace, otherwise return the string itself.
+/** If a string has subparts, get the namespace, otherwise return undefined
  *
  * @example `Table.Header` -> `Table`
  */

--- a/packages/jsx-scanner/src/parsers/assign-parser.ts
+++ b/packages/jsx-scanner/src/parsers/assign-parser.ts
@@ -9,6 +9,7 @@ import {
   type TypeChecker,
 } from 'typescript';
 import { type ComponentDefinition, type ComponentName, getComponentId } from '../entities/component.ts';
+import type { GivenName } from '../entities/declaration.ts';
 import { getRelativeFilePath } from '../entities/file.ts';
 import type { ImportCollection } from '../entities/import.ts';
 import { getPosition, getPositionPath } from '../entities/position.ts';
@@ -31,7 +32,7 @@ function isComponentDefinition(node: Node, typeChecker: TypeChecker) {
 
 type AssignParserArgs = {
   discoveries: JsxScannerDiscovery[];
-  givenName: BindingName;
+  givenName: GivenName;
   importCollection: ImportCollection;
   node: CallExpression;
   sourceFile: SourceFile;
@@ -40,7 +41,7 @@ type AssignParserArgs = {
 
 export function assignParser({
   discoveries,
-  givenName,
+  givenName: namespace,
   importCollection,
   node,
   sourceFile,
@@ -53,8 +54,6 @@ export function assignParser({
   const parts: Record<string, Node> = {};
 
   node.arguments.forEach((argument) => {
-    const namespace = givenName.getText(sourceFile);
-
     // If argument is the parent component, example `Table`
     if (isIdentifier(argument)) {
       if (isComponentDefinition(argument, typeChecker)) {

--- a/packages/jsx-scanner/src/parsers/class-parser.ts
+++ b/packages/jsx-scanner/src/parsers/class-parser.ts
@@ -6,6 +6,7 @@ import {
   type TypeChecker,
 } from 'typescript';
 import { type ComponentDefinition, getComponentId } from '../entities/component.ts';
+import type { GivenName } from '../entities/declaration.ts';
 import { getRelativeFilePath } from '../entities/file.ts';
 import type { ImportCollection } from '../entities/import.ts';
 import { getPosition, getPositionPath } from '../entities/position.ts';
@@ -25,7 +26,7 @@ function getClassType(
 
 type ClassParserArgs = {
   discoveries: JsxScannerDiscovery[];
-  givenName?: Identifier;
+  givenName: GivenName;
   importCollection: ImportCollection;
   node: ClassLikeDeclaration;
   sourceFile: SourceFile;
@@ -34,7 +35,7 @@ type ClassParserArgs = {
 
 export function classParser({
   discoveries,
-  givenName,
+  givenName: componentName,
   importCollection,
   node,
   sourceFile,
@@ -59,7 +60,6 @@ export function classParser({
   const relativeFilePath = getRelativeFilePath(sourceFile.fileName);
   const positionPath = getPositionPath(startPosition, relativeFilePath);
 
-  const componentName = givenName?.getText(sourceFile) ?? '';
   const componentId = getComponentId(componentName, importCollection, relativeFilePath);
 
   const definition: ComponentDefinition = {

--- a/packages/jsx-scanner/src/parsers/element-parser.ts
+++ b/packages/jsx-scanner/src/parsers/element-parser.ts
@@ -34,7 +34,7 @@ export function elementParser({
   const componentId = getComponentId(componentName, importCollection, relativeFilePath);
 
   const importKey = getNamespace(componentName) ?? componentName;
-  const importPath = importCollection.get(importKey);
+  const importMeta = importCollection.get(importKey);
 
   const props = getProps(element.attributes, sourceFile);
 
@@ -42,7 +42,7 @@ export function elementParser({
     type: 'instance',
     componentName,
     componentId,
-    importedFrom: importPath,
+    importedFrom: importMeta?.path,
     filePath: relativeFilePath,
     location: positionPath,
     isSelfClosing,

--- a/packages/jsx-scanner/src/parsers/function-parser.ts
+++ b/packages/jsx-scanner/src/parsers/function-parser.ts
@@ -1,14 +1,13 @@
 import {
   type ArrowFunction,
-  type BindingName,
   type FunctionDeclaration,
   type FunctionExpression,
-  type Identifier,
   type SourceFile,
   type TypeChecker,
 } from 'typescript';
 import { getComponentId } from '../entities/component.ts';
 import type { ComponentDefinition } from '../entities/component.ts';
+import type { GivenName } from '../entities/declaration.ts';
 import { getRelativeFilePath } from '../entities/file.ts';
 import type { ImportCollection } from '../entities/import.ts';
 import { getPosition, getPositionPath } from '../entities/position.ts';
@@ -39,7 +38,7 @@ function getReturnType(
 
 type FunctionParserArgs = {
   discoveries: JsxScannerDiscovery[];
-  givenName?: Identifier | BindingName;
+  givenName: GivenName;
   importCollection: ImportCollection;
   node: FunctionNode;
   sourceFile: SourceFile;
@@ -48,7 +47,7 @@ type FunctionParserArgs = {
 
 export function functionParser({
   discoveries,
-  givenName,
+  givenName: componentName,
   importCollection,
   node,
   sourceFile,
@@ -64,7 +63,6 @@ export function functionParser({
   const relativeFilePath = getRelativeFilePath(sourceFile.fileName);
   const positionPath = getPositionPath(startPosition, relativeFilePath);
 
-  const componentName = givenName?.getText(sourceFile) ?? '';
   const componentId = getComponentId(componentName, importCollection, relativeFilePath);
 
   const definition: ComponentDefinition = {

--- a/packages/jsx-scanner/src/parsers/import-parser.ts
+++ b/packages/jsx-scanner/src/parsers/import-parser.ts
@@ -64,7 +64,7 @@ export function importParser({
   if (node.name) {
     const name = node.name.getText(sourceFile);
 
-    importCollection.set(name, resolvedImportPath);
+    importCollection.set(name, { path: resolvedImportPath, isDefault: true });
   }
 
   /**
@@ -77,7 +77,7 @@ export function importParser({
     node.namedBindings.forEachChild((nameBinding) => {
       const name = getAliasedName(nameBinding, sourceFile) ?? nameBinding.getText(sourceFile);
 
-      importCollection.set(name, resolvedImportPath);
+      importCollection.set(name, { path: resolvedImportPath, isDefault: false });
     });
   }
 }

--- a/packages/jsx-scanner/src/parsers/parser.ts
+++ b/packages/jsx-scanner/src/parsers/parser.ts
@@ -2,12 +2,9 @@ import {
   type CompilerOptions,
   isArrowFunction,
   isCallExpression,
-  isClassDeclaration,
-  isClassExpression,
   isClassLike,
   isFunctionDeclaration,
   isFunctionExpression,
-  isIdentifier,
   isImportClause,
   isJsxElement,
   isJsxFragment,
@@ -15,11 +12,11 @@ import {
   isVariableDeclaration,
   type ModuleResolutionCache,
   type Node,
-  SignatureKind,
   type SourceFile,
   sys as system,
   type TypeChecker,
 } from 'typescript';
+import { getGivenName } from '../entities/declaration.ts';
 import { type ImportCollection } from '../entities/import.ts';
 import { type JsxScannerDiscovery } from '../entities/scanner.ts';
 import { assignParser } from './assign-parser.ts';
@@ -50,7 +47,7 @@ export function parser({
     if (isFunctionDeclaration(node)) {
       functionParser({
         discoveries,
-        givenName: node.name,
+        givenName: getGivenName(node, sourceFile),
         importCollection,
         node,
         sourceFile,
@@ -62,7 +59,7 @@ export function parser({
       if (isFunctionExpression(node.initializer) || isArrowFunction(node.initializer)) {
         functionParser({
           discoveries,
-          givenName: node.name,
+          givenName: getGivenName(node, sourceFile),
           importCollection,
           node: node.initializer,
           sourceFile,
@@ -73,7 +70,7 @@ export function parser({
       if (isCallExpression(node.initializer)) {
         assignParser({
           discoveries,
-          givenName: node.name,
+          givenName: getGivenName(node, sourceFile),
           importCollection,
           node: node.initializer,
           sourceFile,
@@ -83,14 +80,9 @@ export function parser({
     }
 
     if (isClassLike(node)) {
-      // If node is a class expression, get parent node to determine given name
-      const givenName = isClassExpression(node) && isVariableDeclaration(node.parent) && isIdentifier(node.parent.name)
-        ? node.parent.name
-        : node.name;
-
       classParser({
         discoveries,
-        givenName,
+        givenName: getGivenName(node, sourceFile),
         importCollection,
         node,
         sourceFile,


### PR DESCRIPTION
This will make sure `jsx-scanner` handles `default` imports and exports so that they use `default` as a key in their unique id.

Previously those imports/exports were relying on whatever name was being defined for them but because of the nature of `default` it was inconsistent, which lead to components not being grouped correctly.

