### PR TITLE
Use original name for when there is an alias

### DIFF
--- a/packages/jsx-scanner/src/entities/component.ts
+++ b/packages/jsx-scanner/src/entities/component.ts
@@ -51,12 +51,17 @@ export function getComponentId(
     return `svg:${id}`;
   }
 
-  if (importMeta && importMeta.isDefault) {
+  if (importMeta?.isDefault) {
     const id = createUniqueId(`${importMeta.path}:default`);
     return `jsx:${id}`;
   }
 
-  if (importMeta && !importMeta.isDefault) {
+  if (importMeta?.originalName) {
+    const id = createUniqueId(`${importMeta.path}:${importMeta.originalName}`);
+    return `jsx:${id}`;
+  }
+
+  if (importMeta) {
     const id = createUniqueId(`${importMeta.path}:${name}`);
     return `jsx:${id}`;
   }

--- a/packages/jsx-scanner/src/entities/import.ts
+++ b/packages/jsx-scanner/src/entities/import.ts
@@ -3,5 +3,7 @@ export type ImportPath = string;
 export type ImportMeta = {
   isDefault: boolean;
   path: ImportPath;
+  /** The original exported name if an import is aliased. */
+  originalName?: string;
 };
 export type ImportCollection = Map<Import, ImportMeta>;


### PR DESCRIPTION
This will:
- Use `name` (aliased or not) as the `key` for the `importCollection`
- Use `originalName` (the original name given when aliased) as a means to set and get the `componentId`
- Make sure we are grouping by `originalName` instead of `name` when alias but still allow the `name` to be discoverable in the `importCollection`