### PR TITLE
Clean up creation of component definitions and instances

### DIFF
--- a/packages/jsx-scanner/src/entities/component.ts
+++ b/packages/jsx-scanner/src/entities/component.ts
@@ -20,6 +20,27 @@ export type ComponentDefinition = {
   endPosition: Position;
 };
 
+type ComponentDefinitionArgs = Omit<ComponentDefinition, 'type'>;
+
+export function createComponentDefinition({
+  componentId,
+  componentName,
+  filePath,
+  location,
+  startPosition,
+  endPosition,
+}: ComponentDefinitionArgs): ComponentDefinition {
+  return {
+    type: 'definition',
+    componentName,
+    componentId,
+    filePath,
+    location,
+    startPosition,
+    endPosition,
+  };
+}
+
 export type ComponentInstance = {
   type: 'instance';
   componentName: ComponentName;
@@ -32,6 +53,33 @@ export type ComponentInstance = {
   startPosition: Position;
   endPosition: Position;
 };
+
+type CreateComponentInstanceArgs = Omit<ComponentInstance, 'type'>;
+
+export function createComponentInstance({
+  componentId,
+  componentName,
+  filePath,
+  importedFrom,
+  isSelfClosing,
+  location,
+  props,
+  startPosition,
+  endPosition,
+}: CreateComponentInstanceArgs): ComponentInstance {
+  return {
+    type: 'instance',
+    componentName,
+    componentId,
+    importedFrom,
+    filePath,
+    location,
+    isSelfClosing,
+    props,
+    startPosition,
+    endPosition,
+  };
+}
 
 export function getComponentId(
   name: ComponentName,

--- a/packages/jsx-scanner/src/parsers/assign-parser.ts
+++ b/packages/jsx-scanner/src/parsers/assign-parser.ts
@@ -1,5 +1,4 @@
 import {
-  type BindingName,
   type CallExpression,
   isIdentifier,
   isObjectLiteralExpression,
@@ -8,7 +7,7 @@ import {
   type SourceFile,
   type TypeChecker,
 } from 'typescript';
-import { type ComponentDefinition, type ComponentName, getComponentId } from '../entities/component.ts';
+import { type ComponentName, createComponentDefinition, getComponentId } from '../entities/component.ts';
 import type { GivenName } from '../entities/declaration.ts';
 import { getRelativeFilePath } from '../entities/file.ts';
 import type { ImportCollection } from '../entities/import.ts';
@@ -83,15 +82,14 @@ export function assignParser({
     const componentName: ComponentName = partName;
     const componentId = getComponentId(componentName, importCollection, relativeFilePath);
 
-    const definition: ComponentDefinition = {
-      type: 'definition',
+    const definition = createComponentDefinition({
       componentName,
       componentId,
       filePath: relativeFilePath,
       location: positionPath,
       startPosition,
       endPosition,
-    };
+    });
 
     discoveries.push(definition);
   });

--- a/packages/jsx-scanner/src/parsers/class-parser.ts
+++ b/packages/jsx-scanner/src/parsers/class-parser.ts
@@ -1,11 +1,10 @@
 import {
   type ClassLikeDeclaration,
   type ExpressionWithTypeArguments,
-  type Identifier,
   type SourceFile,
   type TypeChecker,
 } from 'typescript';
-import { type ComponentDefinition, getComponentId } from '../entities/component.ts';
+import { createComponentDefinition, getComponentId } from '../entities/component.ts';
 import type { GivenName } from '../entities/declaration.ts';
 import { getRelativeFilePath } from '../entities/file.ts';
 import type { ImportCollection } from '../entities/import.ts';
@@ -62,15 +61,14 @@ export function classParser({
 
   const componentId = getComponentId(componentName, importCollection, relativeFilePath);
 
-  const definition: ComponentDefinition = {
-    type: 'definition',
+  const definition = createComponentDefinition({
     componentName,
     componentId,
     filePath: relativeFilePath,
     location: positionPath,
     startPosition,
     endPosition,
-  };
+  });
 
   discoveries.push(definition);
 }

--- a/packages/jsx-scanner/src/parsers/element-parser.ts
+++ b/packages/jsx-scanner/src/parsers/element-parser.ts
@@ -1,5 +1,5 @@
 import { isJsxSelfClosingElement, type JsxElement, type JsxSelfClosingElement, type SourceFile } from 'typescript';
-import { type ComponentName, getComponentId } from '../entities/component.ts';
+import { type ComponentName, createComponentInstance, getComponentId } from '../entities/component.ts';
 import type { ComponentInstance } from '../entities/component.ts';
 import { getRelativeFilePath } from '../entities/file.ts';
 import type { ImportCollection } from '../entities/import.ts';
@@ -38,8 +38,7 @@ export function elementParser({
 
   const props = getProps(element.attributes, sourceFile);
 
-  const instance: ComponentInstance = {
-    type: 'instance',
+  const instance = createComponentInstance({
     componentName,
     componentId,
     importedFrom: importMeta?.path,
@@ -49,7 +48,7 @@ export function elementParser({
     props,
     startPosition,
     endPosition,
-  };
+  });
 
   discoveries.push(instance);
 }

--- a/packages/jsx-scanner/src/parsers/fragment-parser.ts
+++ b/packages/jsx-scanner/src/parsers/fragment-parser.ts
@@ -1,5 +1,5 @@
 import type { JsxFragment, SourceFile } from 'typescript';
-import { type ComponentInstance, type ComponentName, getComponentId } from '../entities/component.ts';
+import { type ComponentName, createComponentInstance, getComponentId } from '../entities/component.ts';
 import { getRelativeFilePath } from '../entities/file.ts';
 import type { ImportCollection } from '../entities/import.ts';
 import { getPosition, getPositionPath } from '../entities/position.ts';
@@ -27,8 +27,7 @@ export function fragmentParser({
   const componentName: ComponentName = 'React.Fragment';
   const componentId = getComponentId(componentName, importCollection, relativeFilePath);
 
-  const instance: ComponentInstance = {
-    type: 'instance',
+  const instance = createComponentInstance({
     componentName,
     componentId,
     filePath: relativeFilePath,
@@ -37,7 +36,7 @@ export function fragmentParser({
     props: {},
     startPosition,
     endPosition,
-  };
+  });
 
   discoveries.push(instance);
 }

--- a/packages/jsx-scanner/src/parsers/function-parser.ts
+++ b/packages/jsx-scanner/src/parsers/function-parser.ts
@@ -5,7 +5,7 @@ import {
   type SourceFile,
   type TypeChecker,
 } from 'typescript';
-import { getComponentId } from '../entities/component.ts';
+import { createComponentDefinition, getComponentId } from '../entities/component.ts';
 import type { ComponentDefinition } from '../entities/component.ts';
 import type { GivenName } from '../entities/declaration.ts';
 import { getRelativeFilePath } from '../entities/file.ts';
@@ -65,15 +65,14 @@ export function functionParser({
 
   const componentId = getComponentId(componentName, importCollection, relativeFilePath);
 
-  const definition: ComponentDefinition = {
-    type: 'definition',
+  const definition = createComponentDefinition({
     componentName,
     componentId,
     filePath: relativeFilePath,
     location: positionPath,
     startPosition,
     endPosition,
-  };
+  });
 
   discoveries.push(definition);
 }


### PR DESCRIPTION
This will:
- Clean up creation of component definitions and instances so there is more control over the order of their properties without having to manually set them in a specific order every time
- Remove the need to add the `type`