### PR TITLE
Add a separate function for trimming quotes

### DIFF
--- a/packages/jsx-scanner/src/entities/prop.ts
+++ b/packages/jsx-scanner/src/entities/prop.ts
@@ -17,6 +17,7 @@ import {
 } from 'typescript';
 import { isBooleanLiteral } from '../guards/boolean-literal.ts';
 import { isNullLiteral } from '../guards/null-literal.ts';
+import { trimQuotes } from './string.ts';
 
 export type Prop = string;
 export type PropValue = string | boolean | ObjectPropValue | ExpressionPropValue | null | undefined;
@@ -41,7 +42,7 @@ type PropertyAssignmentValue =
 
 function getPropertyAssignmentValue(initializer: Expression, sourceFile?: SourceFile): PropertyAssignmentValue {
   if (isStringLiteral(initializer)) {
-    return initializer.getText(sourceFile).replace(/['"]+/g, '');
+    return trimQuotes(initializer.getText(sourceFile));
   }
 
   if (isNumericLiteral(initializer) || isBooleanLiteral(initializer)) {

--- a/packages/jsx-scanner/src/entities/string.test.ts
+++ b/packages/jsx-scanner/src/entities/string.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { getNamespace } from './string.ts';
+import { getNamespace, trimQuotes } from './string.ts';
 
 describe(getNamespace, () => {
   it('returns the namespace when the string has subparts', () => {
@@ -8,5 +8,19 @@ describe(getNamespace, () => {
 
   it('returns undefined when the string does not have subparts', () => {
     expect(getNamespace('Table')).toBeUndefined();
+  });
+});
+
+describe(trimQuotes, () => {
+  it('removes single quotes from the beginning and end of a string', () => {
+    expect(trimQuotes(`'Table'`)).toBe('Table');
+  });
+
+  it('removes double quotes from the beginning and end of a string', () => {
+    expect(trimQuotes(`"Table"`)).toBe('Table');
+  });
+
+  it('does not remove quotes when the string is not wrapped with quotes', () => {
+    expect(trimQuotes('Table')).toBe('Table');
   });
 });

--- a/packages/jsx-scanner/src/entities/string.ts
+++ b/packages/jsx-scanner/src/entities/string.ts
@@ -1,4 +1,5 @@
-/** If a string has subparts, get the namespace, otherwise return undefined
+/**
+ * If a string has subparts, get the namespace, otherwise return undefined
  *
  * @example `Table.Header` -> `Table`
  */
@@ -10,4 +11,13 @@ export function getNamespace(content: string): string | undefined {
   }
 
   return undefined;
+}
+
+/**
+ * Remove quotes from the beginning or end a string.
+ *
+ * @example `'Table'` -> `Table`
+ */
+export function trimQuotes(content: string): string {
+  return content.replace(/^['"]|['"]$/g, '');
 }

--- a/packages/jsx-scanner/src/parsers/import-parser.ts
+++ b/packages/jsx-scanner/src/parsers/import-parser.ts
@@ -3,13 +3,13 @@ import {
   type ImportClause,
   isImportSpecifier,
   type ModuleResolutionCache,
-  type Node,
   resolveModuleName,
   type SourceFile,
   type System,
 } from 'typescript';
 import { type FilePath, getRelativeFilePath } from '../entities/file.ts';
 import { type ImportCollection, ImportPath } from '../entities/import.ts';
+import { trimQuotes } from '../entities/string.ts';
 
 type ImportParserArgs = {
   compilerOptions: CompilerOptions;
@@ -28,9 +28,10 @@ export function importParser({
   sourceFile,
   system,
 }: ImportParserArgs) {
-  const moduleName = node.parent?.moduleSpecifier
-    .getText(sourceFile)
-    .replace(/['"]+/g, '');
+  const moduleName = trimQuotes(
+    node.parent?.moduleSpecifier
+      .getText(sourceFile),
+  );
 
   const filePath: FilePath = sourceFile.fileName;
   const { resolvedModule } = resolveModuleName(


### PR DESCRIPTION
This will:
- Add a separate function for trimming quotes, `trimQuotes`
- Add tests for `trimQuotes`
- Make it more succinct in that it only removes them from the beginning and end of the value