### PR TITLE
Move system directly into import parser

### DIFF
--- a/packages/jsx-scanner/src/parsers/import-parser.ts
+++ b/packages/jsx-scanner/src/parsers/import-parser.ts
@@ -5,7 +5,7 @@ import {
   type ModuleResolutionCache,
   resolveModuleName,
   type SourceFile,
-  type System,
+  sys as system,
 } from 'typescript';
 import { type FilePath, getRelativeFilePath } from '../entities/file.ts';
 import { type ImportCollection, ImportPath } from '../entities/import.ts';
@@ -17,7 +17,6 @@ type ImportParserArgs = {
   moduleResolutionCache: ModuleResolutionCache;
   node: ImportClause;
   sourceFile: SourceFile;
-  system: System;
 };
 
 export function importParser({
@@ -26,7 +25,6 @@ export function importParser({
   moduleResolutionCache,
   node,
   sourceFile,
-  system,
 }: ImportParserArgs) {
   const moduleName = trimQuotes(
     node.parent?.moduleSpecifier

--- a/packages/jsx-scanner/src/parsers/parser.ts
+++ b/packages/jsx-scanner/src/parsers/parser.ts
@@ -13,7 +13,6 @@ import {
   type ModuleResolutionCache,
   type Node,
   type SourceFile,
-  sys as system,
   type TypeChecker,
 } from 'typescript';
 import { getGivenName } from '../entities/declaration.ts';
@@ -115,7 +114,6 @@ export function parser({
         moduleResolutionCache,
         node,
         sourceFile,
-        system,
       });
     }
 


### PR DESCRIPTION
This will:
- Move `system` directly into where it is being used inside `importParser`