### PR TITLE
Allow synthetic default imports so that we pick up the correct types

### DIFF
--- a/packages/jsx-scanner/src/entities/scanner.ts
+++ b/packages/jsx-scanner/src/entities/scanner.ts
@@ -20,6 +20,8 @@ export async function jsxScanner(config: JsxScannerConfig): Promise<JsxScannerDi
   const compilerOptions: CompilerOptions = {
     jsx: JsxEmit.React,
     checkJs: true,
+    esModuleInterop: true,
+    allowSyntheticDefaultImports: true,
   };
 
   const discoveries: JsxScannerDiscovery[] = [];


### PR DESCRIPTION
This will:
- Add `esModuleInterop` and `allowSyntheticDefaultImports` options by default to jsx-scanner's `compilerOptions`
- Allow the types to be correctly picked up when `import React from 'react'` is being used