### PR TITLE
Simplify ImportCollection so namespace check is part of its getter

### DIFF
--- a/packages/jsx-scanner/src/entities/component.test.ts
+++ b/packages/jsx-scanner/src/entities/component.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import { getComponentId } from './component.ts';
-import type { ImportCollection } from './import.ts';
+import { createImportCollection } from './import.ts';
 
 jest.mock('./unique-id.ts', () => ({
   createUniqueId(value: string) {
@@ -17,7 +17,7 @@ jest.mock('./unique-id.ts', () => ({
 }));
 
 describe(getComponentId, () => {
-  const importCollection: ImportCollection = new Map([
+  const importCollection = createImportCollection([
     ['Example', { path: './example.ts', isDefault: false }],
     ['Button', { path: 'library', isDefault: false }],
     ['Table', { path: 'library', isDefault: false }],

--- a/packages/jsx-scanner/src/entities/component.ts
+++ b/packages/jsx-scanner/src/entities/component.ts
@@ -4,7 +4,6 @@ import { type FilePath } from './file.ts';
 import { type ImportCollection, type ImportPath } from './import.ts';
 import type { Position, PositionPath } from './position.ts';
 import type { Props } from './prop.ts';
-import { getNamespace } from './string.ts';
 import { createUniqueId, type UniqueId } from './unique-id.ts';
 
 export type ComponentId = `${'html' | 'svg' | 'jsx'}:${UniqueId}`;
@@ -86,8 +85,7 @@ export function getComponentId(
   importCollection: ImportCollection,
   filePath: FilePath,
 ): ComponentId {
-  const importkey = getNamespace(name) ?? name;
-  const importMeta = importCollection.get(importkey);
+  const importMeta = importCollection.get(name);
 
   if (isBuiltInHtml(name)) {
     const id = createUniqueId(name);

--- a/packages/jsx-scanner/src/entities/import.test.ts
+++ b/packages/jsx-scanner/src/entities/import.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from '@jest/globals';
+import { createImportCollection, ImportCollection } from './import.ts';
+
+describe(ImportCollection, () => {
+  it('should allow for an import to be added', () => {
+    const importCollection = createImportCollection();
+
+    importCollection.set('React', {
+      path: 'react',
+      isDefault: true,
+    });
+
+    expect(importCollection.get('React')).toEqual({
+      path: 'react',
+      isDefault: true,
+    });
+  });
+
+  it('should allow for an import to be aliased', () => {
+    const importCollection = createImportCollection([
+      ['differentLibrary', {
+        isDefault: false,
+        path: 'library',
+        originalName: 'library',
+      }],
+    ]);
+
+    expect(importCollection.get('differentLibrary')).toEqual({
+      path: 'library',
+      isDefault: false,
+      originalName: 'library',
+    });
+  });
+
+  it('resolves the namespace for an import', () => {
+    const importCollection = createImportCollection([
+      ['React', {
+        isDefault: true,
+        path: 'react',
+      }],
+    ]);
+
+    expect(importCollection.get('React.Fragment')).toEqual({
+      path: 'react',
+      isDefault: true,
+    });
+  });
+});

--- a/packages/jsx-scanner/src/entities/import.ts
+++ b/packages/jsx-scanner/src/entities/import.ts
@@ -1,9 +1,36 @@
-export type Import = string;
+import { getNamespace } from './string.ts';
+
+type ImportKey = string;
 export type ImportPath = string;
-export type ImportMeta = {
+
+type ImportMeta = {
   isDefault: boolean;
   path: ImportPath;
   /** The original exported name if an import is aliased. */
   originalName?: string;
 };
-export type ImportCollection = Map<Import, ImportMeta>;
+
+type ImportCollectionEntry = readonly [ImportKey, ImportMeta];
+
+/**
+ * A collection of import keys mapped to import metadata, including whether the import is default imported, its path, and if aliased its original name.
+ */
+export class ImportCollection extends Map<ImportKey, ImportMeta> {
+  constructor(entries?: readonly ImportCollectionEntry[] | null) {
+    super(entries);
+  }
+
+  set(key: ImportKey, meta: ImportMeta): this {
+    return super.set(key, meta);
+  }
+
+  get(key: ImportKey): ImportMeta | undefined {
+    const resolvedKey = getNamespace(key) ?? key;
+
+    return super.get(resolvedKey);
+  }
+}
+
+export function createImportCollection(entries?: readonly ImportCollectionEntry[] | null): ImportCollection {
+  return new ImportCollection(entries);
+}

--- a/packages/jsx-scanner/src/entities/scanner.ts
+++ b/packages/jsx-scanner/src/entities/scanner.ts
@@ -8,7 +8,7 @@ import {
 } from 'typescript';
 import { parser } from '../parsers/parser.ts';
 import { type ComponentDefinition, type ComponentInstance } from './component.ts';
-import { type ImportCollection } from './import.ts';
+import { createImportCollection, ImportCollection } from './import.ts';
 
 export type JsxScannerDiscovery = ComponentDefinition | ComponentInstance;
 
@@ -49,7 +49,7 @@ export async function jsxScanner(config: JsxScannerConfig): Promise<JsxScannerDi
     // Skip declaration files
     if (sourceFile.isDeclarationFile) return;
 
-    const importCollection: ImportCollection = new Map();
+    const importCollection = createImportCollection();
 
     // Parse the source file
     const parse = parser({

--- a/packages/jsx-scanner/src/parsers/element-parser.ts
+++ b/packages/jsx-scanner/src/parsers/element-parser.ts
@@ -1,12 +1,10 @@
 import { isJsxSelfClosingElement, type JsxElement, type JsxSelfClosingElement, type SourceFile } from 'typescript';
 import { type ComponentName, createComponentInstance, getComponentId } from '../entities/component.ts';
-import type { ComponentInstance } from '../entities/component.ts';
 import { getRelativeFilePath } from '../entities/file.ts';
 import type { ImportCollection } from '../entities/import.ts';
 import { getPosition, getPositionPath } from '../entities/position.ts';
 import { getProps } from '../entities/prop.ts';
 import type { JsxScannerDiscovery } from '../entities/scanner.ts';
-import { getNamespace } from '../entities/string.ts';
 
 type ElementParserArgs = {
   discoveries: JsxScannerDiscovery[];
@@ -33,8 +31,7 @@ export function elementParser({
   const componentName: ComponentName = element.tagName.getText(sourceFile);
   const componentId = getComponentId(componentName, importCollection, relativeFilePath);
 
-  const importKey = getNamespace(componentName) ?? componentName;
-  const importMeta = importCollection.get(importKey);
+  const importMeta = importCollection.get(componentName);
 
   const props = getProps(element.attributes, sourceFile);
 

--- a/packages/jsx-scanner/src/parsers/react-builtin-element-parser.ts
+++ b/packages/jsx-scanner/src/parsers/react-builtin-element-parser.ts
@@ -5,7 +5,7 @@ import type { ImportCollection } from '../entities/import.ts';
 import { getPosition, getPositionPath } from '../entities/position.ts';
 import { parseExpressionToObjectPropValue } from '../entities/prop.ts';
 import type { JsxScannerDiscovery } from '../entities/scanner.ts';
-import { getNamespace, trimQuotes } from '../entities/string.ts';
+import { trimQuotes } from '../entities/string.ts';
 
 export const REACT_BUILTIN_ELEMENT_CALLEES = ['React.createElement', 'createElement'] as const;
 
@@ -37,8 +37,7 @@ export function reactBuiltinElementParser({
   const componentName = trimQuotes(name.getText(sourceFile));
   const componentId = getComponentId(componentName, importCollection, relativeFilePath);
 
-  const importKey = getNamespace(componentName) ?? componentName;
-  const importMeta = importCollection.get(importKey);
+  const importMeta = importCollection.get(componentName);
 
   const instance = createComponentInstance({
     componentId,


### PR DESCRIPTION
This will:
- Move the namespace check to be part of the `importCollection.get` making things more portable and consistent
- Create a new `ImportCollection` that extends `Map`